### PR TITLE
Add HA cluster checkbox button on sizing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,10 @@ Variables **must** be defined in terraform JSON format, and named `variable*.tf.
 
 The following variables will not be displayed on the variable entry form, but will be populated via other application interfaces:
 - `instance_type`: the virtual machine type to be used when starting cloud instances; this will be populated from the _Size Cluster_ page.
-- `instance_count`: the number of virtual machines to be deployed; this will be populate from the _Size Cluster_ page.
+- `instance_count`: the number of virtual machines to be deployed; this will be populated from the _Size Cluster_ page.
 - `region`: the cloud provider's region where services will be established. If _blue-horizon_ is run in a cloud environment; the location will be autodetected via Instance Meta Data Services (IMDS).  
   ⚠ _End users should be notified that the application needs to run in the same region where it will be deployed._
+- `hana_ha_enabled`: checkbox to enable/disable HA capabilities in the HANA cluster; this will be populated from the _Size Cluster_ page. If a `default` value is not set in the `variables.tf.json` file for `hana_ha_enabled` the default value will be false.
 
 To use a different path, set the environment variable `TERRAFORM_SOURCES_PATH` before seeding the database.
 

--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -3,8 +3,9 @@
 class ClustersController < ApplicationController
   def show
     @variable_keys = Variable.load.keys
-    @cluster = ClusterSizeSliderDecorator.new(Cluster.load)
-    @instance_types = Cloud::InstanceType.for(@cluster.cloud_framework)
+    @cluster = Cluster.load
+    @cluster_slider = ClusterSizeSliderDecorator.new(@cluster)
+    @instance_types = Cloud::InstanceType.for(@cluster_slider.cloud_framework)
   end
 
   def update
@@ -20,7 +21,8 @@ class ClustersController < ApplicationController
 
   def cluster_params
     safe_params = params.require(:cluster).permit(
-      :cloud_framework, :instance_type, :instance_type_custom, :instance_count
+      :cloud_framework, :instance_type, :instance_type_custom,
+      :instance_count, :hana_ha_enabled
     )
     safe_params['cloud_framework'] = Rails.configuration.x.cloud_framework
     return safe_params

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -7,8 +7,8 @@ class Cluster
   include Saveable
   extend KeyPrefixable
 
-  attr_accessor :cloud_framework,
-    :instance_count, :instance_type_custom
+  attr_accessor :cloud_framework, :instance_count,
+    :instance_type_custom, :hana_ha_enabled
   attr_writer :instance_type
 
   def initialize(*args)
@@ -24,15 +24,21 @@ class Cluster
     new(
       cloud_framework:      Rails.configuration.x.cloud_framework,
       instance_count:       prefixed_get(:instance_count),
-      instance_type:        prefixed_get(:instance_type),
-      instance_type_custom: prefixed_get(:instance_type_custom)
+      instance_type:        prefixed_get(
+          :instance_type, Variable.load.attributes['instance_type']
+      ),
+      instance_type_custom: prefixed_get(:instance_type_custom),
+      hana_ha_enabled:      prefixed_get(
+        :hana_ha_enabled, Variable.load.attributes['hana_ha_enabled']
+      )
     )
   end
 
   def self.variable_handlers
     [
       'instance_type',
-      'instance_count'
+      'instance_count',
+      'hana_ha_enabled'
     ]
   end
 
@@ -81,5 +87,8 @@ class Cluster
     prefixed_set(:instance_type, @instance_type)
     prefixed_set(:instance_type_custom, @instance_type)
     prefixed_set(:instance_count, @instance_count)
+    prefixed_set(
+      :hana_ha_enabled, ActiveModel::Type::Boolean.new.cast(@hana_ha_enabled)
+    )
   end
 end

--- a/app/views/clusters/_ha_cluster_toggle.html.haml
+++ b/app/views/clusters/_ha_cluster_toggle.html.haml
@@ -1,0 +1,4 @@
+%div.float-left.form-group.form-check.custom-switch
+  = check_box('cluster', 'hana_ha_enabled', class: 'custom-control-input')
+  %label.custom-control-label{ for: "cluster_hana_ha_enabled" }
+    = t('page_subtitle.hana_ha_enabled_info')

--- a/app/views/clusters/show.html.haml
+++ b/app/views/clusters/show.html.haml
@@ -8,6 +8,8 @@
   - if @variable_keys.include?('instance_count')
     = render "cluster_size_panel", form: form
     %p.clearfix
+  - if @variable_keys.include?('hana_ha_enabled')
+    = render "ha_cluster_toggle", form: form
   %div.float-right.btn-group.steps-container
     = link_to welcome_path, class: "btn btn-secondary", title: t('tooltips.prior_step'), data: { toggle: 'tooltip' } do
       %i.eos-icons fast_rewind

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,8 @@ en:
     wrapup: "Next steps after deployment"
 
   page_subtitle:
+    hana_ha_enabled_info: |
+      Enable HA clustering and System Replication
     plan_info: |
       In this step you can generate an execution plan. The execution plan shows what _terraform_ will do when you call deploy. This lets you avoid any surprises when _terraform_ deploys.
     deploy_info: |

--- a/vendor/sources/main.tf
+++ b/vendor/sources/main.tf
@@ -147,7 +147,7 @@ module "bluehorizon" {
   authorized_keys                    = [var.ssh_authorized_key]
   cluster_ssh_pub                    = "salt://sshkeys/cluster.id_rsa.pub"
   cluster_ssh_key                    = "salt://sshkeys/cluster.id_rsa"
-  hana_count                         = var.deployment_type == "HA" ? 2 : 1
+  hana_count                         = var.hana_ha_enabled ? 2 : 1
   os_image                           = local.os_image
   hana_vm_size                       = local.hana_sizes[var.instance_type]["vm_size"]
   hana_data_disks_configuration      = local.hana_sizes[var.instance_type]["data_disks_configuration"]
@@ -158,7 +158,7 @@ module "bluehorizon" {
   hana_primary_site                  = "${var.deployment_name}-siteA"
   hana_secondary_site                = "${var.deployment_name}-siteB"
   hana_cluster_fencing_mechanism     = "sbd"
-  hana_ha_enabled                    = var.deployment_type == "HA" ? true : false
+  hana_ha_enabled                    = var.hana_ha_enabled
   hana_inst_master                   = "${local.storage_account_path}${local.hana_inst_master}"
   hana_archive_file                  = local.hana_archive_file
   storage_account_name               = var.storage_account_name

--- a/vendor/sources/variables.tf.json
+++ b/vendor/sources/variables.tf.json
@@ -28,6 +28,7 @@
     },
     "instance_type": {
       "type": "string",
+      "default": "sap_hana_demo",
       "description": "<!-- [group:HANA_configuration] -->"
     },
     "system_identifier": {
@@ -44,10 +45,10 @@
       "type": "string",
       "description": "SAP administrator password. It is used to access to the sidadm user<!-- password_key [group:HANA_configuration] [pattern:/^[A-Za-z0-9.]{1}(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])[A-Za-z0-9]{7,}$/] [extra_information:The password must contain, at least 8 characters, 1 digit, 1 upper-case character, 1 lower-case character and does not accept special characters]-->"
     },
-    "deployment_type": {
-      "type": "string",
-      "default": "HA",
-      "description": "Select whether the deployment creates a Cluster with HANA system replication and HA capabilities or not<!-- Options=[HA,non HA] [group:HANA_configuration] -->"
+    "hana_ha_enabled": {
+      "type": "bool",
+      "default": true,
+      "description": "<!-- [group:HANA_configuration] -->"
     },
     "hana_installation_software_path": {
       "type": "string",


### PR DESCRIPTION
This PR implements the HA enabled checkbox in the cluster sizing page.
Check the README file to understand how to use it.
![ha_enabled](https://user-images.githubusercontent.com/36370954/97855977-e3d9c180-1cfb-11eb-92fb-1964dcb0599d.gif)
