### PR TITLE
Refactor Terraform validation

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -4,9 +4,10 @@ require 'ruby_terraform'
 # Imported content from terraform sources into an editable format
 class Source < ApplicationRecord
   include Exportable
+  include ActiveModel::Validations
 
   validates :filename, uniqueness: true
-  validate :terraform_validation
+  validates_with SourceValidator
 
   scope :terraform, -> { where('filename LIKE ?', '%.tf') }
   scope :variables, -> { where('filename LIKE ?', 'variable%.tf.json') }
@@ -30,9 +31,5 @@ class Source < ApplicationRecord
       relative_path = filename.to_s.sub("#{source_dir}/", '')
       import(source_dir, relative_path, save_options)
     end
-  end
-
-  def terraform_validation
-    Terraform.new.validate(true)
   end
 end

--- a/app/models/variable.rb
+++ b/app/models/variable.rb
@@ -30,10 +30,6 @@ class Variable
   end
 
   def self.load
-    terra = Terraform.new
-    validation = terra.validate(true, file: true)
-    return { error: validation } if validation
-
     new(Source.variables.pluck(:content))
   end
 

--- a/app/validators/source_validator.rb
+++ b/app/validators/source_validator.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# runs terraform validate with a memoized Terraform instance
+class SourceValidator < ActiveModel::Validator
+  def validate(record)
+    @terraform ||= Terraform.new
+    error_msg = @terraform.validate(true)
+    record.errors[:terraform_syntax] << error_msg if error_msg
+  end
+end

--- a/app/validators/source_validator.rb
+++ b/app/validators/source_validator.rb
@@ -2,12 +2,12 @@
 
 # runs terraform validate with a memoized Terraform instance
 class SourceValidator < ActiveModel::Validator
-  attr_writer :terraform
-
   def validate(record)
     error_msg = terraform.validate(true)
     record.errors[:terraform_syntax] << error_msg if error_msg
   end
+
+  private
 
   def terraform
     @terraform ||= Terraform.new

--- a/app/validators/source_validator.rb
+++ b/app/validators/source_validator.rb
@@ -2,9 +2,14 @@
 
 # runs terraform validate with a memoized Terraform instance
 class SourceValidator < ActiveModel::Validator
+  attr_writer :terraform
+
   def validate(record)
-    @terraform ||= Terraform.new
-    error_msg = @terraform.validate(true)
+    error_msg = terraform.validate(true)
     record.errors[:terraform_syntax] << error_msg if error_msg
+  end
+
+  def terraform
+    @terraform ||= Terraform.new
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,3 +12,4 @@ Rails.logger.level = Logger::INFO
 sources_path = ENV['TERRAFORM_SOURCES_PATH']
 sources_path ||= Rails.root.join('vendor', 'sources')
 Source.import_dir(sources_path, validate: false)
+Terraform.new.validate(true)

--- a/spec/controllers/plans_controller_spec.rb
+++ b/spec/controllers/plans_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PlansController, type: :controller do
     end
 
     it 'sets the configuration' do
-      allow(instance_terra).to receive(:validate).and_return('')
+      allow(instance_terra).to receive(:saved_plan_path)
       allow(instance_terra).to receive(:plan).and_return(error: 'error')
       allow(controller.instance_variable_set(:@exported_vars, 'foo'))
       allow(File).to receive(:exist?).and_return(true)

--- a/spec/features/variable_editing_spec.rb
+++ b/spec/features/variable_editing_spec.rb
@@ -12,8 +12,6 @@ describe 'variable editing', type: :feature do
     ]
   end
   let(:fake_data) { Faker::Crypto.sha256 }
-  let(:terra) { Terraform }
-  let(:instance_terra) { instance_double(Terraform) }
   let(:mock_location) { Faker::Internet.slug }
 
   before { mock_metadata_location(mock_location) }
@@ -23,8 +21,6 @@ describe 'variable editing', type: :feature do
     let(:variables) { Variable.new(Source.variables.pluck(:content)) }
 
     before do
-      allow(terra).to receive(:new).and_return(instance_terra)
-      allow(instance_terra).to receive(:validate)
       populate_sources
       visit('/variables')
     end
@@ -145,9 +141,6 @@ describe 'variable editing', type: :feature do
   end
 
   it 'notifies that no variables are defined' do
-    allow(terra).to receive(:new).and_return(instance_terra)
-    allow(instance_terra).to receive(:validate)
-
     visit('/variables')
     expect(page).to have_content('No variables are defined!')
   end

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Source, type: :model do
   before do
     allow(terra).to receive(:new).and_return(instance_terra)
     allow(instance_terra).to receive(:validate)
+    allow_any_instance_of(SourceValidator).to receive(:terraform).and_return(instance_terra)
   end
 
   it 'has unique filenames' do
@@ -28,11 +29,6 @@ RSpec.describe Source, type: :model do
     let(:short_path) { File.join(source_dir, filename) }
     let(:long_path) { File.join(source_dir, subdir, filename) }
     let(:content) { Faker::Lorem.paragraph }
-
-    before do
-      allow_any_instance_of(described_class)
-        .to receive(:terraform_validation).and_return(true)
-    end
 
     it 'stores the filename without any path if no additional path specified' do
       allow(File).to receive(:read).with(short_path).and_return(content)

--- a/spec/models/source_spec.rb
+++ b/spec/models/source_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Source, type: :model do
   before do
     allow(terra).to receive(:new).and_return(instance_terra)
     allow(instance_terra).to receive(:validate)
-    allow_any_instance_of(SourceValidator).to receive(:terraform).and_return(instance_terra)
+    allow_any_instance_of(SourceValidator).to receive(:terraform)
+      .and_return(instance_terra)
   end
 
   it 'has unique filenames' do

--- a/spec/models/variable_spec.rb
+++ b/spec/models/variable_spec.rb
@@ -85,27 +85,6 @@ RSpec.describe Variable, type: :model do
     end
   end
 
-  context 'when loading wrong formatted script' do
-    let(:message) do
-      { error: 'Incorrect JSON value type on script \'foo.tf.json\''\
-               'in line 42: } This error is highly illogical.' }
-    end
-
-    it 'handles parsing errors from JSON' do
-      allow(instance_terra).to(
-        receive(:validate)
-          .and_return(
-            'Incorrect JSON value type on script \'foo.tf.json\''\
-            'in line 42: } This error is highly illogical.'
-          )
-      )
-      allow(Rails.logger).to receive(:error)
-      allow(File).to receive(:open)
-      allow(Logger::LogDevice).to receive(:new)
-      expect(described_class.load).to eq(message)
-    end
-  end
-
   context 'with form handling' do
     let(:expected_params) do
       [

--- a/spec/validators/source_validator_spec.rb
+++ b/spec/validators/source_validator_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SourceValidator do
+  subject(:validator) { described_class.new }
+
+  let(:terraform) { Terraform }
+  let(:terraform_instance) { instance_double(Terraform) }
+
+  before do
+    allow(terraform).to receive(:new).and_return(terraform_instance)
+  end
+
+  context 'when calling validate multiple times' do
+    it 'initializes Terraform once only' do
+      allow(terraform_instance).to receive(:validate)
+
+      record = Source.new
+      validator.validate(record)
+      validator.validate(record)
+
+      expect(terraform).to have_received(:new).once
+    end
+  end
+
+  context 'when terraform validation fails' do
+    let(:msg) { 'some error message' }
+
+    before do
+      allow(terraform_instance).to receive(:validate).and_return msg
+    end
+
+    it 'records the validation error message' do
+      record = Source.new
+      validator.validate(record)
+
+      expect(record.errors.added?(:terraform_syntax, msg)).to be true
+    end
+  end
+end

--- a/spec/validators/source_validator_spec.rb
+++ b/spec/validators/source_validator_spec.rb
@@ -12,6 +12,19 @@ describe SourceValidator do
     allow(terraform).to receive(:new).and_return(terraform_instance)
   end
 
+  context 'with terraform accessors' do
+    it 'can retrieve the terraform instance' do
+      expect(validator.terraform).to be terraform_instance
+    end
+
+    it 'can set the terraform instance' do
+      another_terraform_instance = instance_double(Terraform)
+      validator.terraform = another_terraform_instance
+      expect(validator.terraform).not_to be terraform_instance
+      expect(validator.terraform).to be another_terraform_instance
+    end
+  end
+
   context 'when calling validate multiple times' do
     it 'initializes Terraform once only' do
       allow(terraform_instance).to receive(:validate)

--- a/spec/validators/source_validator_spec.rb
+++ b/spec/validators/source_validator_spec.rb
@@ -12,19 +12,6 @@ describe SourceValidator do
     allow(terraform).to receive(:new).and_return(terraform_instance)
   end
 
-  context 'with terraform accessors' do
-    it 'can retrieve the terraform instance' do
-      expect(validator.terraform).to be terraform_instance
-    end
-
-    it 'can set the terraform instance' do
-      another_terraform_instance = instance_double(Terraform)
-      validator.terraform = another_terraform_instance
-      expect(validator.terraform).not_to be terraform_instance
-      expect(validator.terraform).to be another_terraform_instance
-    end
-  end
-
   context 'when calling validate multiple times' do
     it 'initializes Terraform once only' do
       allow(terraform_instance).to receive(:validate)


### PR DESCRIPTION
This PR aims at avoiding calling `terraform validate` multiple times each time a page is loaded, which in some cases would amount to loading times in the tens of seconds.

The main source of this problem was the `Variable.load` model method.
Now, I don't really know why would this method require to run `terraform validate` every time, since that just checks for syntax errors.
As far as I could understand, we only need to check the syntax when importing/saving `Source` model entities.

Another source of overhead was the repeated execution of `terraform init`. Since we only need to run this once, the validation of `Source` entities now relies on an external class that memoizes the `Terraform` service instance.

The initialization will still be triggered by controllers that directly invoke `Terraform.new`, so potential changes in the tfcode requiring a new init should still be processed as required.

~~I'm putting this in draft because testing the memoization in RSpec is proving to be problematic.~~