### PR TITLE
Update printed plan headers

### DIFF
--- a/vendor/lib/custom_helpers.rb
+++ b/vendor/lib/custom_helpers.rb
@@ -8,35 +8,6 @@ module CustomHelpers
     find_resources_recursively(plan.dig('planned_values', 'root_module'))
   end
 
-  def plan_section_header(title, icon='abstract')
-    icon_tag = tag.i icon, class: 'eos-icons'
-    tag.h4 icon_tag + title
-  end
-
-  # i don't care about your cyclomatic complexity, rubocop, I want a big dumb switch.
-  def resource_icon(resource) # rubocop:disable Metrics/CyclomaticComplexity
-    case resource['type']
-    when /security_group/
-      'security'
-    when /security_rule/
-      'network_policy'
-    when /subnet$|virtual_network$/
-      'network'
-    when /public_ip$|network_interface$/
-      'ip'
-    when /virtual_machine/
-      'node'
-    when /key/
-      'vpn_key'
-    when /storage/
-      'storage'
-    when /resource_group/
-      'namespace'
-    else
-      'abstract'
-    end
-  end
-
   private
 
   def find_resources_recursively(tf_module)

--- a/vendor/lib/custom_helpers_spec.rb
+++ b/vendor/lib/custom_helpers_spec.rb
@@ -16,29 +16,4 @@ describe CustomHelpers do
       end
     end
   end
-
-  describe 'resource_icon' do
-    resource_type_icon_map = {
-      'azurerm_security_group'                                     => 'security',
-      'azurerm_subnet_network_security_group_association'          => 'security',
-      'azurerm_network_security_rule'                              => 'network_policy',
-      'azurerm_subnet'                                             => 'network',
-      'azurerm_network_interface'                                  => 'ip',
-      'azurerm_public_ip'                                          => 'ip',
-      'azurerm_virtual_machine'                                    => 'node',
-      'tls_private_key'                                            => 'vpn_key',
-      'azurerm_storage_account'                                    => 'storage',
-      'azurerm_resource_group'                                     => 'namespace',
-      'azurerm_subnet_route_table_association'                     => 'abstract',
-      'azurerm_network_interface_backend_address_pool_association' => 'abstract',
-      'foobar'                                                     => 'abstract'
-    }
-
-    resource_type_icon_map.each do |type, icon|
-      it "returns the '#{icon}' icon for the '#{type}' type" do
-        resource = { 'type' => type }
-        expect(helper.resource_icon(resource)).to eq icon
-      end
-    end
-  end
 end

--- a/vendor/views/plans/_plan.haml
+++ b/vendor/views/plans/_plan.haml
@@ -4,7 +4,7 @@
 
   %div.col.system-settings
 
-    = plan_section_header 'System settings', 'settings'
+    %h3 System settings
     %dl.row
       %dt.col-4 System identifier:
       %dd.col-8= plan.dig('variables', 'system_identifier', 'value').upcase
@@ -17,7 +17,7 @@
 
   %div.col.resource-group
 
-    = plan_section_header 'Resource group', 'namespace'
+    %h3 Resource group
     %dl.row
       %dt.col-4 Name:
       %dd.col-8= resources.dig('module.bluehorizon.azurerm_resource_group.myrg[0]', 'values', 'name')
@@ -28,7 +28,7 @@
 
   %div.col-6.virtual-networks
 
-    = plan_section_header 'Virtual networks', 'ip'
+    %h3 Virtual networks
     %dl.row.network
       %dt.col-4 Name:
       %dd.col-8= resources.dig 'module.bluehorizon.azurerm_virtual_network.mynet[0]', 'values', 'name'
@@ -43,7 +43,7 @@
   - if plan.dig('variables', 'hana_ha_enabled', 'value') == true
     %div.col-6.iscsi-server
 
-      = plan_section_header 'ISCSI server', 'storage'
+      %h3 ISCSI server
       %dl.row
         %dt.col-4 Name:
         %dd.col-8= resources.dig 'module.bluehorizon.module.iscsi_server.azurerm_virtual_machine.iscsisrv[0]','values', 'name'
@@ -64,7 +64,7 @@
 
   %div.col.hana-nodes
 
-    = plan_section_header 'HANA nodes', 'node'
+    %h3 HANA nodes
     %div.row
       - node_pattern = /module\.bluehorizon\.module\.hana_node\.azurerm_virtual_machine\.hana/
       - resources.select { |address| address =~ node_pattern }.each_with_index do |(address, vm_resource),index|
@@ -89,7 +89,7 @@
 
   %div.col.bastion
 
-    = plan_section_header 'Bastion', 'security'
+    %h3 Bastion
     %dl.row
       %dt.col-4 Name:
       %dd.col-8= resources.dig 'module.bluehorizon.module.bastion.azurerm_virtual_machine.bastion[0]', 'values', 'name'
@@ -102,7 +102,7 @@
 
   %div.col.monitoring-server
 
-    = plan_section_header 'Monitoring server', 'monitoring'
+    %h3 Monitoring server
     %dl.row
       %dt.col-4 Name:
       %dd.col-8= resources.dig 'module.bluehorizon.module.monitoring.azurerm_virtual_machine.monitoring[0]','values', 'name'
@@ -123,7 +123,7 @@
 
   %div.col.security-group
 
-    = plan_section_header 'Security group', 'network_policy'
+    %h3 Security group
     %dl.row
       %dt.col-2 Name:
       %dd.col-10= resources.dig 'module.bluehorizon.azurerm_network_security_group.mysecgroup', 'values', 'name'


### PR DESCRIPTION
Update printed plan headers to remove the icons and use other styles.
I don't honestly know what to say... I kind of prefer the icons. Opinions?
**In draft stage just to get feedback. I might need to do some cleanup of not used methods if we agree to proceed**

New:
![plan-new](https://user-images.githubusercontent.com/36370954/100849230-8cf21400-3482-11eb-81f9-1b91875f069c.gif)

Old:
![plan-old](https://user-images.githubusercontent.com/36370954/100849309-a8f5b580-3482-11eb-9098-debaffa0eb96.gif)
