### PR TITLE
Mask sap admin password in the plan page

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,3 +24,5 @@
 //= require utility.js
 //= require layout.js
 //= require variables.js
+// Custom
+//= require custom.js

--- a/vendor/assets/javascripts/custom.js
+++ b/vendor/assets/javascripts/custom.js
@@ -1,0 +1,21 @@
+$(function() {
+  // Show/hide passwords
+  $(".plan-icon-append.peek").click(function() {
+    var group = $("div#admin-password");
+    group.find("span.peek").hide()
+    group.find("span.unpeek").show()
+    $(this)
+      .hide()
+      .tooltip("hide");
+    group.find(".plan-icon-append.unpeek").show();
+  });
+  $(".plan-icon-append.unpeek").click(function() {
+    var group = $("div#admin-password");
+    group.find("span.unpeek").hide()
+    group.find("span.peek").show()
+    $(this)
+      .hide()
+      .tooltip("hide");
+    group.find(".plan-icon-append.peek").show();
+  });
+});

--- a/vendor/assets/stylesheets/custom.scss
+++ b/vendor/assets/stylesheets/custom.scss
@@ -43,3 +43,10 @@ table td, table td * {
     color: #6c757d;
     white-space: nowrap;
 }
+
+.plan-icon-append {
+    cursor: pointer;
+    position: absolute;
+    display: inline;
+    padding-left: 20px;
+}

--- a/vendor/lib/plan_spec.rb
+++ b/vendor/lib/plan_spec.rb
@@ -30,7 +30,9 @@ describe 'plan', type: :feature do
     expect(system_settings).to have_text 'System identifier: PRD'
     expect(system_settings).to have_text 'Instance number: 00'
     expect(system_settings).to have_text 'Admin user: prdadm'
-    expect(system_settings).to have_text 'Admin password: .Password1'
+    expect(system_settings).to have_text "Admin password:\n●●●●●●●●●●"
+    expect(system_settings.find('span.unpeek')).to have_content '●●●●●●●●●●'
+    expect(system_settings).to have_css('span.peek', visible: :hidden, text: '.Password1')
 
     resource_group = plan_block.find '.resource-group'
     expect(resource_group).to have_text 'Name: rg-ha-sap-test'

--- a/vendor/views/plans/_plan.haml
+++ b/vendor/views/plans/_plan.haml
@@ -13,7 +13,14 @@
       %dt.col-4 Admin user:
       %dd.col-8= plan.dig('variables', 'system_identifier', 'value').downcase.concat('adm')
       %dt.col-4 Admin password:
-      %dd.col-8= plan.dig('variables', 'sap_admin_password', 'value')
+      %dd.col-8.mb-0
+        %div#admin-password
+          %span.peek{ style: "display: none;" }= plan.dig('variables', 'sap_admin_password', 'value')
+          %span.unpeek ●●●●●●●●●●
+          %div.plan-icon-append.peek{ data: { toggle: 'tooltip' }, title: t(:password_hide), style: "display: none;" }
+            %i.eos-icons.eos-24 visibility
+          %div.plan-icon-append.unpeek{ data: { toggle: 'tooltip' }, title: t(:password_show) }
+            %i.eos-icons.eos-24 visibility_off
 
   %div.col.resource-group
 


### PR DESCRIPTION
Hide/unhide the SAP admin password in the plan view.
Pending to decide how to deal with the `icon` alignment. Now it just pads some pixels right from the text, It doesn't have a fixed place.

New:
![hide-pass-plan](https://user-images.githubusercontent.com/36370954/100883343-867a9100-34b0-11eb-8e8e-7eb00dfa226a.gif)

Before:
![image](https://user-images.githubusercontent.com/36370954/100883485-ac079a80-34b0-11eb-8eb2-52e5585c1da4.png)
