### PR TITLE
Update multi bar deployment by a task list

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -36,43 +36,55 @@ $(function() {
 
 function update_progress_bar(progress_data, error) {
   const bar_id = "#progress-bar";
-  const progress_bar_id = "div" + bar_id;
+  const $progress_bar = $("div" + bar_id);
 
-  $(progress_bar_id).css("width", progress_data.progress + "%");
-  $(progress_bar_id).find("span").html(progress_data.progress + "%");
+  $progress_bar
+    .css("width", progress_data.progress + "%")
+    .find("span").html(progress_data.progress + "%");
   $("label" + bar_id).html(progress_data.text);
-  if (progress_data.progress == 100) {
-    $(progress_bar_id).removeClass("progress-bar-striped progress-bar-animated");
-  } else {
-    $(progress_bar_id).addClass("progress-bar-striped progress-bar-animated");
-  }
+
   if (error !== null) {
-    $(progress_bar_id).addClass("bg-danger");
+    $progress_bar.addClass("bg-danger");
   }
+
+  if (progress_data.progress == 100) {
+    $progress_bar.removeClass("progress-bar-striped progress-bar-animated");
+    return;
+  }
+
+  $progress_bar.addClass("progress-bar-striped progress-bar-animated");
 }
 
 function update_tasks(progress_data) {
   Object.entries(progress_data).forEach(entry=>{
     const [task_id, task_data] = entry;
-    progress_text = task_data.progress + "% - " + task_data.text;
+    const $img_task_id = $("img#" + task_id);
+    const $i_task_id = $("i#" + task_id);
+    const $span_task_id = $("span#" + task_id);
 
-    $("span#" + task_id).html(progress_text);
-    if (task_data.success) {
-      if (task_data.progress < 100) {
-        $("img#" + task_id).show();
-        $("i#" + task_id).hide();
-      } else {
-        $("img#" + task_id).hide();
-        $("i#" + task_id).show();
-        $("i#" + task_id).html("check");
-        $("i#" + task_id).addClass("green");
-      }
-    } else {
-      $("img#" + task_id).hide();
-      $("i#" + task_id).show();
-      $("i#" + task_id).html("close");
-      $("i#" + task_id).addClass("red");
+    progress_text = task_data.progress + "% - " + task_data.text;
+    $span_task_id.html(progress_text);
+
+    if (!task_data.success) {
+      $img_task_id.hide();
+      $i_task_id
+        .show()
+        .html("close")
+        .addClass("red");
+      return;
     }
+
+    if (task_data.progress < 100) {
+      $img_task_id.show();
+      $i_task_id.hide();
+      return;
+    }
+
+    $img_task_id.hide();
+    $i_task_id
+      .show()
+      .html("check")
+      .addClass("green");
   });
 }
 

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -54,11 +54,8 @@ function update_progress_bar(progress_data, error) {
 function update_tasks(progress_data) {
   Object.entries(progress_data).forEach(entry=>{
     const [task_id, task_data] = entry;
-    if ("text" in task_data) {
-      progress_text = task_data.progress + "% - " + task_data.text;
-    } else {
-      progress_text = task_data.progress + "%";
-    }
+    progress_text = task_data.progress + "% - " + task_data.text;
+
     $("span#" + task_id).html(progress_text);
     if (task_data.success) {
       if (task_data.progress < 100) {

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -34,26 +34,47 @@ $(function() {
     });
 });
 
-function update_progress_bar(progress_data) {
+function update_progress_bar(progress_data, error) {
+  const bar_id = "#progress-bar";
+  const progress_bar_id = "div" + bar_id;
+
+  $(progress_bar_id).css("width", progress_data.progress + "%");
+  $(progress_bar_id).find("span").html(progress_data.progress + "%");
+  $("label" + bar_id).html(progress_data.text);
+  if (progress_data.progress == 100) {
+    $(progress_bar_id).removeClass("progress-bar-striped progress-bar-animated");
+  } else {
+    $(progress_bar_id).addClass("progress-bar-striped progress-bar-animated");
+  }
+  if (error !== null) {
+    $(progress_bar_id).addClass("bg-danger");
+  }
+}
+
+function update_tasks(progress_data) {
   Object.entries(progress_data).forEach(entry=>{
-    const [id, bar_data] = entry;
-    const bar_id = "#" + id;
-    if ("text" in bar_data) {
-      progress_text = bar_data.progress + "% - " + bar_data.text;
+    const [task_id, task_data] = entry;
+    if ("text" in task_data) {
+      progress_text = task_data.progress + "% - " + task_data.text;
     } else {
-      progress_text = bar_data.progress + "%";
+      progress_text = task_data.progress + "%";
     }
-    $(bar_id).css("width", bar_data.progress + "%");
-    $(bar_id).find("span").html(progress_text);
-    if (bar_data.success) {
-      if (bar_data.progress < 100) {
-        $(bar_id).addClass("progress-bar-striped progress-bar-animated");
+    $("span#" + task_id).html(progress_text);
+    if (task_data.success) {
+      if (task_data.progress < 100) {
+        $("img#" + task_id).show();
+        $("i#" + task_id).hide();
       } else {
-        $(bar_id).removeClass("progress-bar-striped progress-bar-animated");
+        $("img#" + task_id).hide();
+        $("i#" + task_id).show();
+        $("i#" + task_id).html("check");
+        $("i#" + task_id).addClass("green");
       }
     } else {
-      $(bar_id).removeClass("progress-bar-striped progress-bar-animated");
-      $(bar_id).addClass("bg-danger");
+      $("img#" + task_id).hide();
+      $("i#" + task_id).show();
+      $("i#" + task_id).html("close");
+      $("i#" + task_id).addClass("red");
     }
   });
 }
@@ -92,7 +113,13 @@ function fetch_output(finished, intervalId) {
       }
       // update progress bar
       if ("progress" in data) {
-        update_progress_bar(data.progress)
+        if ("total_progress" in data.progress) {
+          update_progress_bar(
+              data.progress.total_progress, data.error)
+        }
+        if ("tasks_progress" in data.progress) {
+          update_tasks(data.progress.tasks_progress)
+        }
       }
     },
     error: function(data) {

--- a/app/assets/stylesheets/override.scss
+++ b/app/assets/stylesheets/override.scss
@@ -51,7 +51,7 @@ i.eos-icons.no-trailing-space {
 .progress span{
     display: block;
     position: absolute;
-    width: 90%;
+    width: 95%;
     color: black;
 }
 

--- a/app/controllers/concerns/provisioners.rb
+++ b/app/controllers/concerns/provisioners.rb
@@ -106,9 +106,9 @@ module Provisioners
     salt_result_pattern = provisioner_pattern(
       provisioner, PROVISIONING_PATTERNS[:creating]
     )
-    unless content.scan(salt_result_pattern).size.zero?
-      KeyValue.set(provisioner, :initializing)
-    end
+    return if content.scan(salt_result_pattern).size.zero?
+
+    KeyValue.set(provisioner, :initializing)
   end
 
   def wait_until_configuring_os(provisioner, content)
@@ -144,12 +144,9 @@ module Provisioners
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
   # rubocop:disable Metrics/BlockLength
   def update_provisioners_progress(content)
     progress_data = {}
-    return progress_data if content.blank?
-
     provisioners = KeyValue.get(:provisioners)
     provisioners.each do |provisioner|
       progress = 0
@@ -190,6 +187,5 @@ module Provisioners
     return progress_data
   end
   # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/BlockLength
 end

--- a/app/controllers/concerns/provisioners.rb
+++ b/app/controllers/concerns/provisioners.rb
@@ -106,11 +106,8 @@ module Provisioners
     salt_result_pattern = provisioner_pattern(
       provisioner, PROVISIONING_PATTERNS[:creating]
     )
-    if content.scan(salt_result_pattern).size.zero?
-      PROVISIONING_STATES[:not_started]
-    else
+    unless content.scan(salt_result_pattern).size.zero?
       KeyValue.set(provisioner, :initializing)
-      PROVISIONING_STATES[:initializing]
     end
   end
 
@@ -158,11 +155,13 @@ module Provisioners
       progress = 0
       result = true
       text = ''
+      # When the provisioner is in finished, failed or not_started, the progress is not sent
       case KeyValue.get(provisioner)
       when :finished || :failed
         next
       when :not_started
-        text = wait_until_created(provisioner, content)
+        wait_until_created(provisioner, content)
+        next
       when :initializing
         text = wait_until_configuring_os(provisioner, content)
       when :configuring_os

--- a/app/controllers/concerns/provisioners.rb
+++ b/app/controllers/concerns/provisioners.rb
@@ -10,12 +10,12 @@ module Provisioners
   # infrastructure creation bar, as they are the provisioning resources
   EXCLUDED_PATTERN = /.*\.(.*_provision).*\.provision\[(\d+)\]?/.freeze
   PROVISIONING_STATES = {
-    not_started:    I18n.t('provisioning_states.not_started'),
-    initializing:   I18n.t('provisioning_states.initializing'),
-    configuring_os: I18n.t('provisioning_states.configuring_os'),
-    provisioning:   I18n.t('provisioning_states.provisioning'),
-    failed:         I18n.t('provisioning_states.failed'),
-    finished:       I18n.t('provisioning_states.finished')
+    not_started:    I18n.t('deploy.task_states.not_started'),
+    initializing:   I18n.t('deploy.task_states.initializing'),
+    configuring_os: I18n.t('deploy.task_states.configuring_os'),
+    provisioning:   I18n.t('deploy.task_states.provisioning'),
+    failed:         I18n.t('deploy.task_states.failed'),
+    finished:       I18n.t('deploy.task_states.finished')
   }.freeze
 
   PROVISIONING_PATTERNS = {

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -108,11 +108,11 @@ class DeploysController < ApplicationController
     end
 
     text = if error.present?
-      t('deploy.failed')
+      t('deploy.task_states.failed')
     elsif created_resources >= planned_resources_count
-      t('deploy.finished')
+      t('deploy.task_states.finished')
     else
-      t('deploy.creating')
+      t('deploy.task_states.creating')
     end
 
     progress['infra-task'] = {
@@ -125,13 +125,13 @@ class DeploysController < ApplicationController
 
   def update_total_progress(tasks_progress, error)
     '''
-    The methods depends on that once the progress has reached 100 in any of the tasks, the
+    The methods depends on that once the task is finished in any of the tasks, the
     data is not sent again
     '''
     total_steps = KeyValue.get(:total_steps).to_i
     completed_steps = KeyValue.get(:completed_steps).to_i
     tasks_progress.each_value do |task|
-      if task[:progress] == 100
+      if task[:text] == Provisioners::PROVISIONING_STATES[:finished]
         completed_steps += 1
         KeyValue.set(:completed_steps, completed_steps)
       end

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -92,8 +92,6 @@ class DeploysController < ApplicationController
 
   def update_terraform_progress(content, error)
     progress = {}
-    return progress if content.blank?
-
     state = KeyValue.get(:resource_creation_state)
     return progress if state == :finished
 
@@ -124,10 +122,8 @@ class DeploysController < ApplicationController
   end
 
   def update_total_progress(tasks_progress, error)
-    '''
-    The methods depends on that once the task is finished in any of the tasks, the
-    data is not sent again
-    '''
+    # The methods depends on that once the task is finished in any of the tasks, the
+    # data is not sent again
     total_steps = KeyValue.get(:total_steps).to_i
     completed_steps = KeyValue.get(:completed_steps).to_i
     tasks_progress.each_value do |task|
@@ -147,14 +143,13 @@ class DeploysController < ApplicationController
 
     progress = {
       progress: completed_steps * 100 / total_steps,
-      text: text
+      text:     text
     }
     return progress
   end
 
   def update_progress(content, error)
     progress = {}
-    tasks_progress = {}
     return progress if content.blank?
 
     terraform_progress = update_terraform_progress(content, error)

--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -3,6 +3,18 @@
 # Helpers used in deploy page
 module DeploysHelper
   def titleize_provisioner(provisioner)
-    t("provisioning_bars.#{provisioner}")
+    title = t("provisioning_bars.#{provisioner}")
+    "#{title}..."
+  end
+
+  def task_loading_icon(id)
+    tag.img(
+      src:   asset_path('bubble_loading.svg'),
+      alt:   t('tooltips.loading'),
+      title: t('tooltips.loading'),
+      class: 'eos-icons eos-18',
+      style: 'display: none;',
+      id:    id
+    )
   end
 end

--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -3,7 +3,7 @@
 # Helpers used in deploy page
 module DeploysHelper
   def titleize_provisioner(provisioner)
-    title = t("provisioning_bars.#{provisioner}")
+    title = t("deploy.task_list.#{provisioner}")
     "#{title}..."
   end
 

--- a/app/views/deploys/_progress_bar.html.haml
+++ b/app/views/deploys/_progress_bar.html.haml
@@ -2,17 +2,17 @@
 %ul.task-list
   %li
     %div
-      %span.task-description #{t("deploy.infra_label")}...
+      %span.task-description #{t("deploy.task_list.infra_label")}...
       %i.eos-icons.eos-18{ :id => "infra-task" } schedule
       = task_loading_icon("infra-task")
-      %span.task-progress{ :id => "infra-task" } 0% - #{t("provisioning_states.not_started")}
+      %span.task-progress{ :id => "infra-task" } 0% - #{t("deploy.task_states.not_started")}
   - @provisioners.each do |provisioner|
     %li
       %div
         %span.task-description= titleize_provisioner(provisioner)
         %i.eos-icons.eos-18{ :id => provisioner } schedule
         = task_loading_icon(provisioner)
-        %span.task-progress{ :id => provisioner } 0% - #{t("provisioning_states.not_started")}
+        %span.task-progress{ :id => provisioner } 0% - #{t("deploy.task_states.not_started")}
 %hr
 %div.progress{ :style => "height:40px" }
   %div.progress-bar#progress-bar{ :style => "width:0%;height:40px" }

--- a/app/views/deploys/_progress_bar.html.haml
+++ b/app/views/deploys/_progress_bar.html.haml
@@ -1,11 +1,20 @@
-%label{ :for => "infra-bar" }= t('deploy.infra_label').titleize
-%div.progress{ :style => "height:30px" }
-  %div.progress-bar#infra-bar{ :style => "width:0%;height:30px" }
+%h4 Task list
+%ul.task-list
+  %li
+    %div
+      %span.task-description #{t("deploy.infra_label")}...
+      %i.eos-icons.eos-18{ :id => "infra-task" } schedule
+      = task_loading_icon("infra-task")
+      %span.task-progress{ :id => "infra-task" } 0% - #{t("provisioning_states.not_started")}
+  - @provisioners.each do |provisioner|
+    %li
+      %div
+        %span.task-description= titleize_provisioner(provisioner)
+        %i.eos-icons.eos-18{ :id => provisioner } schedule
+        = task_loading_icon(provisioner)
+        %span.task-progress{ :id => provisioner } 0% - #{t("provisioning_states.not_started")}
+%hr
+%div.progress{ :style => "height:40px" }
+  %div.progress-bar#progress-bar{ :style => "width:0%;height:40px" }
     %span 0%
-%p.clearfix
-- @provisioners.each do |provisioner|
-  %label{ :for => provisioner }= titleize_provisioner(provisioner)
-  %div.progress{ :style => "height:30px" }
-    %div.progress-bar{ :id => provisioner, :style => "width:0%;height:30px" }
-      %span 0%
-  %p.clearfix
+%label#progress-bar{ :for => "progress-bar", :style => "text-align:center" }= t("deploy.not_started")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -129,26 +129,25 @@ en:
   variable_groups:
     ungrouped: Additional data
 
+  # Deployment view and progress bar texts
   deploy:
     details: "Installation details"
-    infra_label: "Infrastructure creation"
     not_started: "Not started"
-    creating: "Creating resources..."
     in_progress: "Installation in progress..."
     finished: "Finished"
     failed: "Failed"
-
-  provisioning_bars:
-    hana_provision_0: "First HANA database server provisioning"
-    hana_provision_1: "Second HANA database server provisioning"
-    bastion_provision_0: "Bastion server provisioning"
-    iscsi_provision_0: "iSCSI server provisioning"
-    monitoring_provision_0: "Monitoring server provisioning"
-
-  provisioning_states:
-    not_started: "Not started"
-    initializing: "Initializing machine..."
-    configuring_os: "Configuring operative system..."
-    provisioning: "Provisioning machine..."
-    failed: "Failed"
-    finished: "Finished"
+    task_list:
+      infra_label: "Infrastructure creation"
+      hana_provision_0: "First HANA database server provisioning"
+      hana_provision_1: "Second HANA database server provisioning"
+      bastion_provision_0: "Bastion server provisioning"
+      iscsi_provision_0: "iSCSI server provisioning"
+      monitoring_provision_0: "Monitoring server provisioning"
+    task_states:
+      not_started: "Not started"
+      creating: "Creating resources..."
+      initializing: "Initializing machine..."
+      configuring_os: "Configuring operative system..."
+      provisioning: "Provisioning machine..."
+      failed: "Failed"
+      finished: "Finished"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,7 +132,9 @@ en:
   deploy:
     details: "Installation details"
     infra_label: "Infrastructure creation"
+    not_started: "Not started"
     creating: "Creating resources..."
+    in_progress: "Installation in progress..."
     finished: "Finished"
     failed: "Failed"
 

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -41,9 +41,10 @@ describe 'deploy', type: :feature do
 
       visit(deploy_path)
 
-      expect(page).to have_selector('div.progress-bar#infra-bar')
-      expect(page).to have_selector('div.progress-bar#hana_provision_0')
-      expect(page).to have_selector('div.progress-bar#hana_provision_1')
+      expect(page).to have_selector('span#infra-task')
+      expect(page).to have_selector('span#hana_provision_0')
+      expect(page).to have_selector('span#hana_provision_1')
+      expect(page).to have_selector('div.progress-bar#progress-bar')
     end
   end
 end

--- a/vendor/assets/stylesheets/custom.scss
+++ b/vendor/assets/stylesheets/custom.scss
@@ -50,3 +50,27 @@ table td, table td * {
     display: inline;
     padding-left: 20px;
 }
+
+.task-list {
+  padding-left: 15px;
+}
+
+.task-list div {
+  display: flex;
+}
+
+span.task-description {
+  padding-right: 10px;
+}
+
+span.task-progress {
+  font-weight: bold;
+}
+
+i.green {
+  color: #30BA78; // $eos-bc-green-500
+}
+
+i.red {
+  color: #C5161F; // $eos-bc-red-900
+}

--- a/vendor/locales/custom-en.yml
+++ b/vendor/locales/custom-en.yml
@@ -3,9 +3,9 @@
 
 en:
   # Application title - shown on the home page
-  title: "Blue Horizon for SLES4SAP"
+  title: "SUSE SAP console"
   # Abbreviated title for use in navigation
-  short_title: "BlueHorizon"
+  short_title: "SUSE SAP console"
   # Sidebar
   sidebar:
     welcome: "Deployment"
@@ -107,15 +107,10 @@ en:
   # Long-form description of steps to take after deployment
   # Markdown syntax is accepted - see https://daringfireball.net/projects/markdown/syntax
   next_steps: |
-    To destroy the currently created deployment run the following commands in the folder extracted from the downloaded file:
+    # Welcome to you SUSE SAP console!
+    Your SAP environment has been created successfully.
+    You can find the created resources [clicking here](%{resource_group_url}).
 
-    ```terraform init```
-
-    ```terraform workspace select $used_workspace```
-
-    ```terraform destroy -auto-approve```
-
-    To access the machines the next command can be used:<br>
-    ```terraform output # get the addresses```
+    Now, you can continue using the SAP console to monitor and tune the created machines using the top menu.
 
   footer: "© 2019-2020 SUSE, all rights reserved."


### PR DESCRIPTION
**Draft mode. Unit tests and styles are missing. Only check the styles and the logic please**
Replace the multi bar deployment by a task list.

Some comments:
- The general progress bar just shows the percentage of the finished tasks. This means, 2 tasks of 5 finished. It will have 40% width.
- When the task is not started we have the `schedule` icon
- The `loading gif` during the process
- A `green check` if finished without errors
- A `red cancel` if it was an error
- All the texts are configurable though the locales language file

FYI: @cyntss

Old:
![multi_bar_progress](https://user-images.githubusercontent.com/36370954/101163931-ac30a300-3634-11eb-9c75-8b5831300565.gif)

New:
![task-list](https://user-images.githubusercontent.com/36370954/101163943-afc42a00-3634-11eb-8a11-098172ceff34.gif)
![image](https://user-images.githubusercontent.com/36370954/101163961-b652a180-3634-11eb-8c2b-6e017e572e52.png)

