### PR TITLE
Redesign cluster sizing page for SAP

### DIFF
--- a/app/assets/stylesheets/instance_type.scss
+++ b/app/assets/stylesheets/instance_type.scss
@@ -3,32 +3,39 @@
 .instance-type-selector {
   //background-color: $panel-default-heading-bg;
 
+  .instance-size {
+    padding-top: 10px;
+  }
+
   .instance-types {
     border-right: 1px solid $table-border-color;
+  }
 
-    .form-group {
-      margin-bottom: 0;
-    }
+  .card-deck {
+    padding-right: 30px;
   }
 
   label.instance-type {
     display: inline-block;
+    padding-top: 10px;
 
     input[type="radio"] {
       display: none;
 
       &:checked + .instance-type-box {
-        background-color: $success;
-        color: $white;
         box-shadow: none;
+        .card-header {
+          color: $white;
+          background-color: $success;
+        }
       }
     }
 
     .instance-type-box {
       display: inline-block;
       overflow: hidden;
-      width: 140px;
-      height: 140px;
+      width: 150px;
+      height: 150px;
 
       @media screen and (max-width: 1335px) {
         width: 120px;
@@ -41,21 +48,27 @@
       }
 
       border: 1px solid $table-border-color;
-      border-radius: 5px;
-      box-shadow: 1px 1px 6px 1px $table-border-color;
+      border-radius: 10px;
+      box-shadow: 3px 3px 8px 3px $table-border-color;
 
       background: $white;
-      color: $success;
 
       cursor: pointer;
 
       margin: 10px;
-      padding: 10px;
 
       font-size: 14pt;
-      text-align: center;
+      text-align: left;
       font-weight: normal;
       word-wrap: break-word;
+
+      .card-body {
+        padding-top: 0.10rem !important;
+      }
+
+      .card-header {
+          background-color: white;
+      }
 
       &.double {
         width: 316px;

--- a/app/helpers/clusters_helper.rb
+++ b/app/helpers/clusters_helper.rb
@@ -5,4 +5,11 @@ module ClustersHelper
   def instance_types_doc_url_for(framework)
     Rails.configuration.x.external_instance_types_link[framework]
   end
+
+  def card_text(instance_type)
+    saps = instance_type.details['SAP application performance standard']
+    # Get memory part from details box and remove last word
+    memory = instance_type.details['Details'].split(',')[1][/(.*)\s/, 1].strip
+    "Up to #{memory} database size and #{saps}"
+  end
 end

--- a/app/views/clusters/_ha_cluster_toggle.html.haml
+++ b/app/views/clusters/_ha_cluster_toggle.html.haml
@@ -1,4 +1,5 @@
-%div.float-left.form-group.form-check.custom-switch
+%p=markdown(t('page_subtitle.hana_ha_info'))
+%div.form-group.form-check.custom-switch
   = check_box('cluster', 'hana_ha_enabled', class: 'custom-control-input')
   %label.custom-control-label{ for: "cluster_hana_ha_enabled" }
-    = t('page_subtitle.hana_ha_enabled_info')
+    = t('page_subtitle.hana_ha_enabled_label')

--- a/app/views/clusters/_instance_type_panel.html.haml
+++ b/app/views/clusters/_instance_type_panel.html.haml
@@ -1,47 +1,54 @@
 %div.card
+  %h3.card-header= t('page_title.cluster')
   %div.card-body.instance-type-selector
+    %p= markdown(t('page_subtitle.cluster_info'))
+    %hr
     %div.row
-      %div.col-md-8.instance-types
-        %div.form-group
-          - @instance_types.each do |instance_type|
-            %label.instance-type
-              = form.radio_button :instance_type, instance_type.key
-              %div.instance-type-box
-                = instance_type.category.name
-                %br
-                %small= instance_type.name
-              %div.definition
-                %h3= instance_type.category.name
-                %h4= instance_type.name
-                %p= markdown(instance_type.category.description)
-                %p
-                  - instance_type.category.features.each do |feature|
-                    %span.label.label-default= markdown(feature)
-                %dl
-                  - if instance_type.vcpu_count
-                    %dt vCPUs
-                    %dd.vcpu-count{ data: { vcpus: instance_type.vcpu_count } }
-                      = pluralize(instance_type.vcpu_count, 'core')
-                  - if instance_type.ram_bytes
-                    %dt RAM
-                    %dd.ram-size{ data: { bytes: instance_type.ram_bytes, si: instance_type.ram_si_units } }
-                  - instance_type.details.each do |key, value|
-                    %dt= key
-                    %dd= markdown(value)
-          - if Rails.configuration.x.allow_custom_instance_type
-            %label.instance-type
-              = form.radio_button :instance_type, 'CUSTOM'
-              %div.instance-type-box.double
-                Other types&hellip;
-                %br
-                %br
-                %small= form.text_field :instance_type_custom, class: "form-control", style: "display: none;"
-              %div.definition
-                %p
-                  You may specify a preferred instance type with a minimum of
-                  are 2 vCPUs and 8GB of RAM; 4 vCPUs are recommended.
+      %div.col-md-6.instance-types
+        %h4 SAP HANA Deployment
+        = render "ha_cluster_toggle", form: form
+        %p.clearfix
+        %div.instance-size
+          %label Select a deployment size
+          %div.form-group.card-deck
+            - @instance_types.each do |instance_type|
+              %label.instance-type
+                = form.radio_button :instance_type, instance_type.key
+                %div.card.instance-type-box
+                  %h6.card-header= instance_type.name
+                  %div.card-body
+                    %p.card-text= card_text(instance_type)
+                %div.definition
+                  %h4= instance_type.name
+                  %p= markdown(instance_type.category.description)
+                  %p
+                    - instance_type.category.features.each do |feature|
+                      %span.label.label-default= markdown(feature)
+                  %dl
+                    - if instance_type.vcpu_count
+                      %dt vCPUs
+                      %dd.vcpu-count{ data: { vcpus: instance_type.vcpu_count } }
+                        = pluralize(instance_type.vcpu_count, 'core')
+                    - if instance_type.ram_bytes
+                      %dt RAM
+                      %dd.ram-size{ data: { bytes: instance_type.ram_bytes, si: instance_type.ram_si_units } }
+                    - instance_type.details.each do |key, value|
+                      %dt= key
+                      %dd= markdown(value)
+            - if Rails.configuration.x.allow_custom_instance_type
+              %label.instance-type
+                = form.radio_button :instance_type, 'CUSTOM'
+                %div.instance-type-box.double
+                  Other types&hellip;
+                  %br
+                  %br
+                  %small= form.text_field :instance_type_custom, class: "form-control", style: "display: none;"
+                %div.definition
+                  %p
+                    You may specify a preferred instance type with a minimum of
+                    are 2 vCPUs and 8GB of RAM; 4 vCPUs are recommended.
 
-      %div.col-md-4.instance-type-description
+      %div.col-md-6.instance-type-description
   - if Rails.configuration.x.show_instance_type_tip
     %div.card-footer
       = tip_icon

--- a/app/views/clusters/show.html.haml
+++ b/app/views/clusters/show.html.haml
@@ -8,8 +8,6 @@
   - if @variable_keys.include?('instance_count')
     = render "cluster_size_panel", form: form
     %p.clearfix
-  - if @variable_keys.include?('hana_ha_enabled')
-    = render "ha_cluster_toggle", form: form
   %div.float-right.btn-group.steps-container
     = link_to welcome_path, class: "btn btn-secondary", title: t('tooltips.prior_step'), data: { toggle: 'tooltip' } do
       = t('sidebar.welcome')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -98,14 +98,19 @@ en:
     loading: "Loading..."
 
   page_title:
+    cluster: "SAP System size"
     plan: "Plan your deployment"
     deploy: "Deploy your cluster"
     wrapup: "Next steps after deployment"
     source: "Working directly with deployment source scripts"
 
   page_subtitle:
-    hana_ha_enabled_info: |
-      Enable HA clustering and System Replication
+    hana_ha_info: |
+      High Available clustering and system replication option creates a clustered environment with 2 SAP HANA nodes, providing a resilient landscape that reduces downtime but increases cost.
+    hana_ha_enabled_label: |
+      HA clustering and System Replication
+    cluster_info: |
+      Select the High Availability options and size of the SAP environment.
     plan_info: |
       In this step an execution plan is generated. The plan shows what *terraform* will do when you deploy, so you know exactly what to expect.
     deploy_info: |

--- a/spec/features/cluster_sizing_spec.rb
+++ b/spec/features/cluster_sizing_spec.rb
@@ -17,16 +17,10 @@ describe 'cluster sizing', type: :feature do
     let(:cloud_framework) { 'azure' }
     let(:instance_types) do
       Cloud::InstanceType.load(
-        Rails.root.join('config', 'data', "#{cloud_framework}-types.json")
+        Rails.root.join('vendor', 'data', "#{cloud_framework}-types.json")
       )
     end
     let(:random_instance_type_key) { instance_types.sample.key }
-    let(:cluster_size_config) { Rails.configuration.x.cluster_size }
-    let(:random_cluster_size) do
-      Faker::Number.within(
-        range: cluster_size_config.min..cluster_size_config.max
-      )
-    end
 
     before do
       Rails.configuration.x.cloud_framework = cloud_framework
@@ -45,47 +39,8 @@ describe 'cluster sizing', type: :feature do
       end
     end
 
-    it 'stores cluster sizing' do
-      mock_metadata_location(mock_location)
-
-      choose(random_instance_type_key)
-      fill_in('cluster_instance_count', with: random_cluster_size)
-      click_on(id: 'submit-cluster')
-      cluster = Cluster.load
-      expect(cluster.instance_type).to eq(random_instance_type_key)
-      expect(cluster.instance_count).to eq(random_cluster_size)
-    end
-
-    it 'does not stores cluster sizing and shows error' do
-      choose(random_instance_type_key)
-      fill_in('cluster_instance_count', with: random_cluster_size)
-      cluster_instance = Cluster.new(
-        cloud_framework: 'azure', instance_type: random_instance_type_key,
-        instance_count: '173'
-      )
-      active_model_errors = ActiveModel::Errors.new(cluster_instance).tap do |e|
-        e.add(:size, 'is wrong')
-      end
-
-      allow(Cluster).to receive(:new).and_return(cluster_instance)
-      allow(cluster_instance).to receive(:save).and_return(false)
-      allow(cluster_instance).to(
-        receive(:errors)
-          .and_return(active_model_errors)
-      )
-      click_on(id: 'submit-cluster')
-      expect(page).to have_content('Size is wrong')
-    end
-
-    it 'consistently shows the cluster size' do
-      KeyValue.set('tfvars.instance_count', random_cluster_size)
-      visit '/cluster'
-      expect(page).to have_selector(
-        "input#count-display[value='#{random_cluster_size}']"
-      )
-      expect(page).to have_selector(
-        "input#cluster_instance_count[value='#{random_cluster_size}']"
-      )
+    it 'HA toggle is present' do
+      expect(page).to have_selector('input#cluster_hana_ha_enabled')
     end
   end
 end

--- a/vendor/assets/stylesheets/custom.scss
+++ b/vendor/assets/stylesheets/custom.scss
@@ -50,3 +50,8 @@ table td, table td * {
     display: inline;
     padding-left: 20px;
 }
+
+.custom-switch .custom-control-label {
+    cursor: pointer;
+    display: inline-block;
+}

--- a/vendor/data/azure-types.json
+++ b/vendor/data/azure-types.json
@@ -15,37 +15,41 @@
             "category": "sap_hana",
             "details": {
                 "Description":"This setup creates a small demo system with a SAP HANA database, not for production use",
+                "SAP application performance standard": "< 7.500 SAPs",
                 "Azure Instance type used": "E8s_v3",
                 "Details":"8 vCPUs, 64 GB Memory"
-        
+
             }
         },
         "small_sap_hana": {
             "sort_value": "01",
-            "name": "Small < 30.000 SAPS",
+            "name": "Small",
             "category": "sap_hana",
             "details": {
                 "Description":"This setup creates a small system with a SAP HANA database, not for production use",
+                "SAP application performance standard": "< 30.000 SAPs",
                 "Azure Instance type used": "E32s_v3",
                 "Details":"32 vCPUs, 256 GB Memory"
             }
         },
         "medium_sap_hana": {
             "sort_value": "02",
-            "name": "Medium < 70.000 SAPS",
+            "name": "Medium",
             "category": "sap_hana",
             "details": {
                 "Description":"This setup creates a medium system with a SAP HANA database, with SAP certified instance types for production use",
+                "SAP application performance standard": "< 70.000 SAPs",
                 "Azure Instance type used": "E64s_v3",
                 "Details":"64 vCPUs, 432 GB Memory"
             }
         },
         "large_sap_hana": {
             "sort_value": "03",
-            "name": "Large < 180.000 SAPS",
+            "name": "Large",
             "category": "sap_hana",
             "details": {
                 "Description":"This setup creates a large system with a SAP HANA database, with SAP certified instance types for production use",
+                "SAP application performance standard": "< 180.000 SAPs",
                 "Azure Instance type used": "M64s",
                 "Details":"64 vCPUs, 1024 GB Memory"
             }

--- a/vendor/sources/variables.tf.json
+++ b/vendor/sources/variables.tf.json
@@ -47,7 +47,7 @@
     },
     "hana_ha_enabled": {
       "type": "bool",
-      "default": true,
+      "default": false,
       "description": "<!-- [group:HANA_configuration] -->"
     },
     "hana_installation_software_path": {


### PR DESCRIPTION
New design for the cluster sizing page.

Besides that, I have disabled by default the HA options as suggested by @diegoakechi

Most of the texts are configurable through the `config/locales/en.yml`  files.

**Disclaimer**: I have not implemented some of the styles provided by UX, as they are part of the general content of the web, and they require a major change. The changes only affect to the cluster sizing major content part.

Based on: https://xd.adobe.com/view/314d024c-baca-4db8-ad3d-bb2c58c46434-641e/

FYI: @cyntss

Some pics:

![image](https://user-images.githubusercontent.com/36370954/101775043-34102480-3aef-11eb-9666-c3f2f32f0acf.png)
![image](https://user-images.githubusercontent.com/36370954/101775073-3d00f600-3aef-11eb-9284-bfb21023ec75.png)


