### PR TITLE
remove eos-icons-font from Gemfile.production

### DIFF
--- a/Gemfile.production
+++ b/Gemfile.production
@@ -3,7 +3,6 @@
 source 'https://rubygems.org'
 
 gem 'active_link_to'
-gem 'eos-icons-font'
 gem 'cloud-instancetype', '~> 1.1'
 gem 'haml-rails', '~> 2.0'
 gem 'jbuilder', '~> 2.5'

--- a/Gemfile.production.lock
+++ b/Gemfile.production.lock
@@ -48,8 +48,6 @@ GEM
     cloud-instancetype (1.1.0)
     concurrent-ruby (1.1.5)
     crass (1.0.6)
-    eos-icons-font (4.3.1)
-      railties (>= 3.1)
     erubi (1.9.0)
     erubis (2.7.0)
     globalid (0.4.2)
@@ -150,7 +148,6 @@ PLATFORMS
 DEPENDENCIES
   active_link_to
   cloud-instancetype (~> 1.1)
-  eos-icons-font
   haml-rails (~> 2.0)
   jbuilder (~> 2.5)
   puma (>= 3.11)
@@ -161,4 +158,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3.6)
 
 BUNDLED WITH
-   2.0.2
+   2.1.4


### PR DESCRIPTION
This gem was removed from the development one but left in the production Gemfile. It's not needed because we embed those sources.