### PR TITLE
Hotfix/deployment with errors

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -89,14 +89,15 @@ function update_tasks(progress_data, finished) {
 }
 
 function update_progress(data, finished) {
-  if ("progress" in data) {
-    if ("total_progress" in data.progress) {
-      update_progress_bar(
-          data.progress.total_progress, data.error, finished)
-    }
-    if ("tasks_progress" in data.progress) {
-      update_tasks(data.progress.tasks_progress, finished)
-    }
+  if (!("progress" in data)) {
+    return;
+  }
+  if ("total_progress" in data.progress) {
+    update_progress_bar(
+      data.progress.total_progress, data.error, finished);
+  }
+  if ("tasks_progress" in data.progress) {
+    update_tasks(data.progress.tasks_progress, finished);
   }
 }
 

--- a/app/controllers/concerns/provisioners.rb
+++ b/app/controllers/concerns/provisioners.rb
@@ -154,7 +154,9 @@ module Provisioners
       text = ''
       # When the provisioner is in finished, failed or not_started, the progress is not sent
       case KeyValue.get(provisioner)
-      when :finished || :failed
+      when :finished
+        next
+      when :failed
         next
       when :not_started
         wait_until_created(provisioner, content)

--- a/spec/controllers/deploys_controller_spec.rb
+++ b/spec/controllers/deploys_controller_spec.rb
@@ -372,7 +372,7 @@ RSpec.describe DeploysController, type: :controller do
 
     it 'updates the provisioner progress - failed' do
       KeyValue.set(:hana_provision_0, :provisioning)
-      data = "#{provisioning_deploy_output}.hana_provision.provision[0] (remote-exec): Error::Deployment failed"
+      data = "#{provisioning_deploy_output}.hana_provision.provision[0] (remote-exec): Failed:  3\n--------"
       progress = example.send(
         :update_progress, data, nil
       )

--- a/spec/controllers/deploys_controller_spec.rb
+++ b/spec/controllers/deploys_controller_spec.rb
@@ -410,6 +410,13 @@ RSpec.describe DeploysController, type: :controller do
       )
 
       expect(progress['tasks_progress']['hana_provision_0']).to eq(nil)
+
+      KeyValue.set(:hana_provision_0, :failed)
+      progress = example.send(
+        :update_progress, provisioning_deploy_output, nil
+      )
+
+      expect(progress['tasks_progress']['hana_provision_0']).to eq(nil)
     end
   end
 end

--- a/vendor/customization.json
+++ b/vendor/customization.json
@@ -33,7 +33,7 @@
     ],
     "provisioning_patterns": {
       "planned_states_count": ".*Total planned states count: (\\d+)$",
-      "deployment_failed": ".*::Deployment failed$",
+      "deployment_failed": ".*Failed:.*[1-9]+\\n.*----",
       "configuring_os": ".*Configuring operative system...$",
       "provisioning": ".*Provisioning system...$"
     }


### PR DESCRIPTION
Fix the next errors:
- Incorrect usage of ruby's `case` statement. The `||` was not working properly. This was causing the progress data being sent after finished with `0` as percentage
- Display properly the bar styles when the deployment is finished. It was not removing the animated styles
- Set the failed icon in some task if the deployment is finished and it doesn't have 100 as percentage. This can happen as terraform doesn't sent the whole output when it fails... 