### PR TITLE
Implement the Azure login step

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -25,5 +25,6 @@
 //= require layout.js
 //= require variables.js
 //= require resources.js
+//= require login.js
 // Custom
 //= require custom.js

--- a/app/assets/javascripts/login.js
+++ b/app/assets/javascripts/login.js
@@ -1,0 +1,18 @@
+$(function() {
+  $("#logout, #login")
+    .bind("ajax:beforeSend", function() {
+      $(".float-left .btn").addClass("disabled");
+      $(this).addClass("no-hover");
+      $("a[data-toggle]").tooltip("hide");
+      $("#loading").show();
+      $("#subscription").empty();
+    })
+    .bind("ajax:complete", function() {
+      $(this).removeClass("no-hover");
+      $("#loading").hide();
+      $(".float-left .btn").removeClass("disabled");
+    })
+    .bind("ajax:error", function() {
+      console.log('error');
+    });
+});

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'azurecli'
+
+class LoginsController < ApplicationController
+  def show
+    @logged_account = AzureCli.new.logged_account
+    if @logged_account[:logged]
+      KeyValue.set(:active_logged_user, true)
+    end
+
+    respond_to do |format|
+      format.html
+      format.js { render :layout => false, :action => "refresh" }
+      format.json do
+        render json: { logged_account: @logged_account }
+      end
+    end
+  end
+
+  def update
+    @code = AzureCli.new.login
+    respond_to do |format|
+      format.js { render :layout => false, :action => "refresh" }
+    end
+  end
+
+  def destroy
+    AzureCli.new.logout
+    @logged_account = AzureCli.new.logged_account
+    KeyValue.set(:active_logged_user, false)
+    respond_to do |format|
+      format.js { render :layout => false, :action => "refresh" }
+    end
+  end
+end

--- a/app/services/azurecli.rb
+++ b/app/services/azurecli.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'json'
+
+# Class to wrap all azure cli operations
+class AzureCli
+  def logged_account
+    Open3.popen3('az account show') do |stdin, stdout, stderr, wait_thr|
+
+      if wait_thr.value.exitstatus.zero?
+        account_data = JSON.parse(stdout.read())
+        subscription = account_data['name']
+        user = account_data['user']['name']
+      end
+
+      return {
+        logged: wait_thr.value.exitstatus.zero?,
+        subscription: subscription,
+        user: user
+      }
+    end
+  end
+
+  def login
+    stdin, stdout, stderr, wait_thr = Open3.popen3('az login --use-device-code')
+    while msg = stderr.gets()
+      if code = msg.match(/.*enter the code (.*) to authenticate/)
+        return code.captures[0]
+      end
+    end
+  end
+
+  def logout
+    Open3.popen3('az logout') do |stdin, stdout, stderr, wait_thr|
+      return wait_thr.value.exitstatus.zero?
+    end
+  end
+end

--- a/app/views/clusters/show.html.haml
+++ b/app/views/clusters/show.html.haml
@@ -9,8 +9,8 @@
     = render "cluster_size_panel", form: form
     %p.clearfix
   %div.float-right.btn-group.steps-container
-    = link_to welcome_path, class: "btn btn-secondary", title: t('tooltips.prior_step'), data: { toggle: 'tooltip' } do
-      = t('sidebar.welcome')
+    = link_to login_path, class: "btn btn-secondary", title: t('tooltips.prior_step'), data: { toggle: 'tooltip' } do
+      = t('sidebar.login')
     %button.btn.btn-primary#submit-cluster{ type: 'submit', title: t('tooltips.next_step'), data: { toggle: 'tooltip' } }
       = t('sidebar.variables')
 %p.clearfix

--- a/app/views/logins/_subscription.html.haml
+++ b/app/views/logins/_subscription.html.haml
@@ -1,0 +1,18 @@
+- if @code.present?
+  %dl.row
+    %dt.col-2 Code:
+    %dd.col-10=@code
+  %p.clearfix
+  %span= 'Use the next link and the provided code to Login in your Azure subscription: '
+  = link_to "Login page", "https://microsoft.com/devicelogin", target: "_blank"
+  %p.clearfix
+  %span= 'After authenticating in the Azure portal wait until the login process is identified (it might take some few seconds)'
+- elsif @logged_account[:logged]
+  %h4 Currently logged as:
+  %dl.row
+    %dt.col-2 Subscription:
+    %dd.col-10=@logged_account[:subscription]
+    %dt.col-2 User:
+    %dd.col-10=@logged_account[:user]
+- else
+  %p= 'There is not any user logged in yet. Start the login process'

--- a/app/views/logins/refresh.js.haml
+++ b/app/views/logins/refresh.js.haml
@@ -1,0 +1,34 @@
+$("#subscription").html("#{j (render partial: 'subscription')}");
+- if @code.present?
+  // Start an active polling to check if the login has worked
+  fetch_state();
+- elsif @logged_account && @logged_account[:logged]
+  $("#login").hide();
+  $("#logout").show();
+  $(".steps-container").find(".btn-primary").removeClass("disabled");
+- else
+  $("#login").show();
+  $("#logout").hide();
+  $(".steps-container").find(".btn-primary").addClass("disabled");
+
+function fetch_state() {
+$.ajax({
+type: "GET",
+url: "login",
+dataType: "json",
+success: function(data) {
+if (data.logged_account.logged) {
+// This additional Ajax call is used to render the new partial with the updated data
+$.ajax({
+type: "GET",
+url: "login",
+dataType: "script"
+});
+} else {
+setTimeout(function() {
+fetch_state();
+}, 5000);
+}
+}
+});
+}

--- a/app/views/logins/show.html.haml
+++ b/app/views/logins/show.html.haml
@@ -1,0 +1,28 @@
+%div.card
+  %h3.card-header= t('page_title.login')
+  %div.card-body
+    %p= markdown(t('page_subtitle.login_info'))
+    %hr
+    = loading_icon(hide: true)
+    %div#subscription
+      = render('logins/subscription')
+    %hr
+    %div.float-left
+      - if @logged_account[:logged]
+        = link_to login_path, class: "btn btn-primary", id: "logout", title: t('tooltips.logout'), data: { method: :delete, remote: true, toggle: 'tooltip' } do
+          = t('action.logout')
+        = link_to login_path, class: "btn btn-primary", style: "display: none", id: "login", title: t('tooltips.login'), data: { method: :put, remote: true, toggle: 'tooltip' } do
+          = t('action.login')
+      - else
+        = link_to login_path, class: "btn btn-primary", id: "login", title: t('tooltips.login'), data: { method: :put, remote: true, toggle: 'tooltip' } do
+          = t('action.login')
+        = link_to login_path, class: "btn btn-primary", style: "display: none", id: "logout", title: t('tooltips.logout'), data: { method: :delete, remote: true, toggle: 'tooltip' } do
+          = t('action.logout')
+
+%p.clearfix
+  %div.float-right.btn-group.steps-container
+    - logged = @logged_account[:logged]
+    = link_to welcome_path, class: "btn btn-secondary", title: t('tooltips.prior_step'), data: { toggle: 'tooltip' } do
+      = t('sidebar.welcome')
+    = link_to cluster_path, class: "btn btn-primary #{'disabled' if !logged}", title: t('tooltips.next_step'), data: { toggle: 'tooltip' } do
+      = t('sidebar.cluster')

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -11,7 +11,7 @@
   - if Rails.configuration.x.terraform_sources_url.present?
     %button.btn.btn-lg.btn-secondary{ type: 'button', data: { toggle: 'modal', target: '#source' } }
       %i.eos-icons.no-trailing-space edit
-  %a.btn.btn-lg.btn-primary{ href: cluster_path }
-    = t('sidebar.simple')
+  %a.btn.btn-lg.btn-primary{ href: login_path }
+    = t('sidebar.login')
 - if Rails.configuration.x.terraform_sources_url.present?
   = render 'welcome/source'

--- a/config/initializers/navigation.rb
+++ b/config/initializers/navigation.rb
@@ -5,6 +5,7 @@ Rails.application.configure do
   # EOS icon names for each navigation path
   config.x.sidebar_icons = {
     welcome:   'announcement',
+    login:     'login',
     cluster:   'photo_size_select_small',
     variables: 'playlist_add',
     plan:      'organization',
@@ -16,6 +17,7 @@ Rails.application.configure do
   # menus for each path
   config.x.menu_items = [
     :welcome,
+    :login,
     :cluster,
     :variables,
     :plan,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
   deploy: "Deploy"
   terraform_files: "terraform scripts and log"
   non_active_session: "Duplicate session!"
+  non_user_logged: "There is not a logged user. Run the login process first"
   session_reset: "The active session has been reset."
   password_show: "Show password"
   password_hide: "Hide password"
@@ -53,6 +54,10 @@ en:
     reset_session: "Reset session"
     affirm: "OK"
     plan: "Update plan"
+    login: "Login"
+    logout: "Logout"
+    refresh_login: "Refresh"
+    refreshing: "Refreshing"
 
   sidebar:
     welcome: "Welcome"
@@ -65,6 +70,7 @@ en:
     wrapup: "Next steps"
     download: "Download"
     simple: "Start setup"
+    login: "Cloud credentials"
 
   console_sidebar:
     ha_cluster: "HA cluster"
@@ -99,6 +105,9 @@ en:
     loading: "Loading..."
     copy: "Copy to clipboard"
     copied: "Copied!"
+    login: "Login to your Azure subscription"
+    logout: "Logout the current user"
+    refresh_login: "Refresh login status"
 
   page_title:
     cluster: "SAP System size"
@@ -107,6 +116,7 @@ en:
     wrapup: "Next steps after deployment"
     source: "Working directly with deployment source scripts"
     resources: "Additional resources"
+    login: "Login to your Azure subscription"
 
   page_subtitle:
     hana_ha_info: |
@@ -123,6 +133,8 @@ en:
       Your application has been deployed, here's how to use it.
     resources_info: |
       Find here additional resources to use the project. [Download](/download) your results and follow the instructions below.
+    login_info: |
+      Login to your Azure subscription to enable the deployment. The SAP environment resources are created with this user.
 
   content:
     explain_duplicate_session: |

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
   resource :plan, only: [:show, :update]
   # Deploy
   resource :deploy, only: [:update, :destroy]
+  # Login
+  resource :login, only: [:show, :update, :destroy]
 
   resources :dashboards, only: [:show]
 


### PR DESCRIPTION
Implement the Azure login step.

**This implementation might not be used, but as I have already implemented, I'm creating a PR to keep track of it**

The implementation uses `azure-cli` to login.  Basically, it adds a new initial stage to do so, that redirects the user to the Azure login portal.
The user cannot proceed without this step, and it it's not done, it will redirect any request to the initial page with an error.

**TODO**:
- Create unit tests
- logout after the deployment is done. This will prevent storing user access token in the machine
- The implementation doesn't work with the currently published `azure-cli` set of packages (`2.0.45`). It works with a new release candidate `2.14.2`.

Some shots:
![image](https://user-images.githubusercontent.com/36370954/104593099-7a691e00-566f-11eb-842c-72b94628a84f.png)
![image](https://user-images.githubusercontent.com/36370954/104593117-81902c00-566f-11eb-9c63-e727d0b304e9.png)
![image](https://user-images.githubusercontent.com/36370954/104593166-910f7500-566f-11eb-8ce4-98aa6e8c8e95.png)


