### PR TITLE
Add Azure service principal variables usage

### DIFF
--- a/vendor/locales/custom-en.yml
+++ b/vendor/locales/custom-en.yml
@@ -52,6 +52,13 @@ en:
     <summary class="welcome">Pre-requirements</summary>
 
     <ol>
+    <li><span>Create an Azure Service Principal. This can be done either by using the Azure portal or the <code>az</code> CLI.</span>
+    <ul>
+    <li><span>Follow the instrucions in <a href="https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/service_principal_client_secret">this link</a> in order to create the Service Principal using the Azure portal.</span></li>
+    <li><span>Use the <code>az ad sp create-for-rbac</code> command. Find more information <a href="https://docs.microsoft.com/en-us/cli/azure/create-an-azure-service-principal-azure-cli">here.</a>The data provided as output from this function will be required in the next steps.</span></li>
+    </ul>
+    <span>Note the SP must have sufficient privileges, the created account must have at least Contributor.
+    </li>
     <li><span>You need to have ssh-keys to be able to access the deployed machines.</span></li>
     <li><p>The SAP software must be available in Azure, in order to be installed by the solution.</p>
 

--- a/vendor/sources/main.tf
+++ b/vendor/sources/main.tf
@@ -1,9 +1,3 @@
-# Configure the Azure Provider
-provider "azurerm" {
-  version = "~> 2.32.0"
-  features {}
-}
-
 locals {
   hana_sizes = {
     demo_sap_hana = {
@@ -169,6 +163,11 @@ module "bluehorizon" {
   hana_archive_file                  = local.hana_archive_file
   storage_account_name               = var.storage_account_name
   storage_account_key                = var.storage_account_key
+  # The next 4 variables are only introduced to enalbe the Service Principal usage
+  subscription_id                    = var.subscription_id
+  client_id                          = var.client_id
+  client_secret                      = var.client_secret
+  tenant_id                          = var.tenant_id
   monitoring_enabled                 = true
   pre_deployment                     = true
   provisioning_log_level             = "info"

--- a/vendor/sources/variables.tf.json
+++ b/vendor/sources/variables.tf.json
@@ -26,6 +26,22 @@
       "type": "string",
       "description": "Azure storage account access key. Check **Setting up the Storage account** in the initial page for more information<!-- password_key [group:Azure_configuration] -->"
     },
+    "subscription_id": {
+      "type": "string",
+      "description": "Azure subscription ID. Check **Pre-requirements** in the initial page for more information<!-- [group:Azure_configuration] -->"
+    },
+    "client_id": {
+      "type": "string",
+      "description": "Azure Service Principal 'appId'. Check **Pre-requirements** in the initial page for more information<!-- [group:Azure_configuration] -->"
+    },
+    "client_secret": {
+      "type": "string",
+      "description": "Azure Service Principal 'password'. Check **Pre-requirements** in the initial page for more information<!-- password_key [group:Azure_configuration] -->"
+    },
+    "tenant_id": {
+      "type": "string",
+      "description": "Azure Service Principal 'tenant'. Check **Pre-requirements** in the initial page for more information<!-- [group:Azure_configuration] -->"
+    },
     "instance_type": {
       "type": "string",
       "default": "sap_hana_demo",


### PR DESCRIPTION
Enable Azure service principal usage. **The service principal data is not used in this terraform file, as the azure resources are created in the module. That's why I have removed the `provider` declaration. The variables are bypassed to the module**.
Depends on: https://github.com/SUSE/ha-sap-terraform-deployments/pull/614

Besides that, add an additional entry in the initial page explaining how to create the SP:
![image](https://user-images.githubusercontent.com/36370954/104713919-d0e46400-5724-11eb-9715-aa28ed3a7638.png)

The variables page:
![image](https://user-images.githubusercontent.com/36370954/104714357-6a137a80-5725-11eb-96c8-b2fcf614a104.png)

