### PR TITLE
Use specific version for tls provider and remove azurerm

### DIFF
--- a/vendor/sources/main.tf
+++ b/vendor/sources/main.tf
@@ -1,7 +1,5 @@
-# Configure the Azure Provider
-provider "azurerm" {
-  version = "~> 2.32.0"
-  features {}
+provider "tls" {
+  version = "3.0.0"
 }
 
 locals {


### PR DESCRIPTION
Define a specific version for the `tls` provider and remove `azurerm` as it is not used in this terraform file.

This is required to avoid the download of the latest version, and as we ship this provider under SLE, we must use the provided version.