### PR TITLE
Add azurerm provider with authentication variables

### DIFF
--- a/vendor/sources/main.tf
+++ b/vendor/sources/main.tf
@@ -1,3 +1,13 @@
+provider "azurerm" {
+  version = "~> 2.32.0"
+  features {}
+
+  subscription_id = var.subscription_id
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+  tenant_id       = var.tenant_id
+}
+
 provider "tls" {
   version = "3.0.0"
 }


### PR DESCRIPTION
Without this field, the terraform execution fails with `Error: "features": required field is not set` error, which is because the `azurerm` provider is not declared.

It is pretty strange, as in this particular terraform file the provider is not used...