### PR TITLE
Feature/non supported badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,14 @@ The `"key"` must match a translation value in the `menu` scope (e.g. `menu.more-
 The `"sidebar"` entry is used to create a new sidebar panel when the link in the top menu items are accessed.
 Each of the entries in the sidebar will render a grafana iframe (the iframe url can be composed with variables coming from `terraform output` using the `%{var}` syntax) in the content container. If the entry has other hash, it will create a dropdown menu in this item with the same functionality (only one nested layer is allowed). The names in the sidebar (like `ha_cluster`, `hana_dbs` or `systemdb`) can be customized in the translation configuration file changing the values in `console_sidebar`.
 
+In order to add the `non-supported/beta` badge to any of the sidebar elements use the `unsupported_sidebar_items` item. This list includes all the items that have this badge. The element must match the id of the added sidebar element. The next example adds the badge in the `ha_cluster` sidebar item.
+
+```
+"unsupported_sidebar_items": [
+  "ha_cluster"
+]
+```
+
 ### Provisioning bars
 
 The provisioning bars used in the deployment show the progress of each of the individuals provisioning. The provisioning progress is based in the terraform output (that includes salt output) and it looks for certain patterns to know which is the current state of the execution.

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,9 +18,9 @@ module ApplicationHelper
   end
 
   def bootstrap_unsupported(sidebar_key)
-    if Rails.configuration.x.unsupported_sidebar_items.include?(sidebar_key.to_s)
-      return render('layouts/unsupported').html_safe
-    end
+    return unless Rails.configuration.x.unsupported_sidebar_items.include?(sidebar_key.to_s)
+
+    return render('layouts/unsupported').html_safe
   end
 
   def custom_image_exists?(filename)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,6 +17,15 @@ module ApplicationHelper
     end.join.html_safe
   end
 
+  def bootstrap_unsupported(request_id=nil)
+    Rails.configuration.x.top_menu_items.collect do |menu_item|
+      if menu_item['key'].to_s == request_id.to_s && menu_item['unsupported'].present?
+        return render('layouts/unsupported').html_safe
+      end
+    end
+    return
+  end
+
   def custom_image_exists?(filename)
     base_path = Rails.root.join('vendor', 'assets', 'images')
     File.exist?(File.join(base_path, "#{filename}.svg"))   ||

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,13 +17,10 @@ module ApplicationHelper
     end.join.html_safe
   end
 
-  def bootstrap_unsupported(request_id=nil)
-    Rails.configuration.x.top_menu_items.collect do |menu_item|
-      if menu_item['key'].to_s == request_id.to_s && menu_item['unsupported'].present?
-        return render('layouts/unsupported').html_safe
-      end
+  def bootstrap_unsupported(sidebar_key)
+    if Rails.configuration.x.unsupported_sidebar_items.include?(sidebar_key.to_s)
+      return render('layouts/unsupported').html_safe
     end
-    return
   end
 
   def custom_image_exists?(filename)

--- a/app/views/layouts/_console_sidebar_menu_items.haml
+++ b/app/views/layouts/_console_sidebar_menu_items.haml
@@ -14,6 +14,7 @@
             = link_to get_url(subkey), id: subkey, class: "menu-title js-select-current" do
               %i.eos-icons label
               = t("console_sidebar.#{subkey}") % @outputs
+              = bootstrap_unsupported(@request_id)
 
   - else
     %li.menu-item
@@ -22,3 +23,4 @@
       = link_to get_url(key), id: key, class: "menu-title js-select-current" do
         %i.eos-icons label
         %span.menu-title-content= t("console_sidebar.#{text}") % @outputs
+        = bootstrap_unsupported(@request_id)

--- a/app/views/layouts/_console_sidebar_menu_items.haml
+++ b/app/views/layouts/_console_sidebar_menu_items.haml
@@ -14,7 +14,7 @@
             = link_to get_url(subkey), id: subkey, class: "menu-title js-select-current" do
               %i.eos-icons label
               = t("console_sidebar.#{subkey}") % @outputs
-              = bootstrap_unsupported(@request_id)
+              = bootstrap_unsupported(subkey)
 
   - else
     %li.menu-item
@@ -23,4 +23,4 @@
       = link_to get_url(key), id: key, class: "menu-title js-select-current" do
         %i.eos-icons label
         %span.menu-title-content= t("console_sidebar.#{text}") % @outputs
-        = bootstrap_unsupported(@request_id)
+        = bootstrap_unsupported(key)

--- a/app/views/layouts/_unsupported.html.haml
+++ b/app/views/layouts/_unsupported.html.haml
@@ -1,0 +1,3 @@
+%div.unsupported
+  %h1
+    %span.badge.badge-warning.unsupported{ title: t('tooltips.unsupported')}= t('unsupported')

--- a/app/views/layouts/_unsupported.html.haml
+++ b/app/views/layouts/_unsupported.html.haml
@@ -1,3 +1,1 @@
-%div.unsupported
-  %h1
-    %span.badge.badge-warning.unsupported{ title: t('tooltips.unsupported')}= t('unsupported')
+%span.badge.badge-warning.unsupported{ title: t('tooltips.unsupported')}= t('unsupported')

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -55,10 +55,8 @@
             = top_menu_items(@request_id, @outputs)
           =render('layouts/more_info')
       %div{ class: container_type }
-        = bootstrap_unsupported(@request_id)
         = bootstrap_flash
         = yield
-
     %footer.footer-content.js-footer-content
       %ul.footer-list
         %li.footer-list-item= source_footer

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -55,8 +55,10 @@
             = top_menu_items(@request_id, @outputs)
           =render('layouts/more_info')
       %div{ class: container_type }
+        = bootstrap_unsupported(@request_id)
         = bootstrap_flash
         = yield
+
     %footer.footer-content.js-footer-content
       %ul.footer-list
         %li.footer-list-item= source_footer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,7 +40,7 @@ en:
   password_show: "Show password"
   password_hide: "Hide password"
   autoscroll: "Autoscroll"
-  unsupported: "Unsupported view"
+  unsupported: "Beta*"
 
   #password key is used to check whether a form field should be of type
   # "password" rather than "text"
@@ -100,7 +100,7 @@ en:
     loading: "Loading..."
     copy: "Copy to clipboard"
     copied: "Copied!"
-    unsupported: "Current view is not under a supported license"
+    unsupported: "Current view is not under a supported license. Provided as on-preview mode"
 
   page_title:
     cluster: "SAP System size"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,7 @@ en:
   password_show: "Show password"
   password_hide: "Hide password"
   autoscroll: "Autoscroll"
+  unsupported: "Unsupported view"
 
   #password key is used to check whether a form field should be of type
   # "password" rather than "text"
@@ -99,6 +100,7 @@ en:
     loading: "Loading..."
     copy: "Copy to clipboard"
     copied: "Copied!"
+    unsupported: "Current view is not under a supported license"
 
   page_title:
     cluster: "SAP System size"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -100,7 +100,7 @@ en:
     loading: "Loading..."
     copy: "Copy to clipboard"
     copied: "Copied!"
-    unsupported: "Current view is not under a supported license. Provided as on-preview mode"
+    unsupported: "Beta features are not covered by SUSE Enterprise Support licenses and are only provided as a technical preview"
 
   page_title:
     cluster: "SAP System size"

--- a/spec/features/dashboards_spec.rb
+++ b/spec/features/dashboards_spec.rb
@@ -34,6 +34,7 @@ describe 'dashboards', type: :feature do
       )
 
       Rails.configuration.x.top_menu_items = top_menu_data
+      Rails.configuration.x.unsupported_sidebar_items = ['ha_cluster']
 
       allow_any_instance_of(Terraform).to receive(:outputs).and_return(
         {
@@ -58,6 +59,9 @@ describe 'dashboards', type: :feature do
 
       nav = find('div.mm-navigation-container').find('div.nav-wrap')
       dropdown = nav.find('li.menu-dropdown')
+
+      ha_cluster = nav.find('a#ha_cluster')
+      expect(ha_cluster).to have_content('Beta*')
 
       expect(nav).to have_link('HA cluster', href: ha_cluster_url)
       expect(dropdown).to have_link('PRD', href: main_tenant_url)

--- a/vendor/assets/stylesheets/custom.scss
+++ b/vendor/assets/stylesheets/custom.scss
@@ -104,7 +104,7 @@ div.ssh-command {
 
 // Unsupported badge styles
 .unsupported {
-  position: absolute;
-  right: 30px;
-  top: 11px;
+  float: right;
+  margin-right: 15px;
+  margin-top: 3px;
 }

--- a/vendor/assets/stylesheets/custom.scss
+++ b/vendor/assets/stylesheets/custom.scss
@@ -74,7 +74,7 @@ i.green {
 i.red {
   color: #C5161F; // $eos-bc-red-900
 }
-  
+
 .custom-switch .custom-control-label {
     cursor: pointer;
     display: inline-block;
@@ -100,4 +100,11 @@ div.ssh-command {
     padding-left: 12px;
     padding-right: 15px;
   }
+}
+
+// Unsupported badge styles
+.unsupported {
+  position: absolute;
+  right: 30px;
+  top: 30px;
 }

--- a/vendor/assets/stylesheets/custom.scss
+++ b/vendor/assets/stylesheets/custom.scss
@@ -106,5 +106,5 @@ div.ssh-command {
 .unsupported {
   position: absolute;
   right: 30px;
-  top: 30px;
+  top: 11px;
 }

--- a/vendor/customization.json
+++ b/vendor/customization.json
@@ -18,6 +18,7 @@
       {
           "key": "tuning",
           "url": "/dashboards/tuning",
+          "unsupported": true,
           "sidebar": {
             "tuning": "http://%{bastion_ip}:3000/d/HzFepKtMz/tuning?orgId=1&kiosk"
           }

--- a/vendor/customization.json
+++ b/vendor/customization.json
@@ -18,7 +18,6 @@
       {
           "key": "tuning",
           "url": "/dashboards/tuning",
-          "unsupported": true,
           "sidebar": {
             "tuning": "http://%{bastion_ip}:3000/d/HzFepKtMz/tuning?orgId=1&kiosk"
           }
@@ -31,6 +30,9 @@
             "resources": "/resources"
           }
       }
+    ],
+    "unsupported_sidebar_items": [
+      "tuning"
     ],
     "provisioning_patterns": {
       "planned_states_count": ".*Total planned states count: (\\d+)$",


### PR DESCRIPTION
Add `non supported/beta` badge to some views.

This can be customized using the `unsupported_sidebar_items` in the customization file. 
By now, it only adds the badge to the `tuning` view.

The texts (tooltip included) are configurable using the language files.
![non-supported](https://user-images.githubusercontent.com/36370954/104908149-531f9300-5986-11eb-96f2-b0ce973c181a.gif)