### PR TITLE
Fix disk configuration values for the different deployment sizes

### DIFF
--- a/vendor/sources/main.tf
+++ b/vendor/sources/main.tf
@@ -18,11 +18,11 @@ locals {
       vm_size                       = "Standard_E8s_v3"
       enable_accelerated_networking = false
       data_disks_configuration = {
-        disks_type       = "Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS"
-        disks_size       = "128,128,128,128,128,128,128"
-        caching          = "ReadOnly,ReadOnly,None,None,ReadOnly,ReadOnly,ReadOnly"
-        writeaccelerator = "false,false,false,false,false,false,false"
-        luns             = "0,1#2,3#4#5#6#7"
+        disks_type       = "Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS"
+        disks_size       = "128,128,128,128,128,128,128,128"
+        caching          = "ReadOnly,ReadOnly,None,None,ReadOnly,ReadOnly,ReadOnly,ReadOnly"
+        writeaccelerator = "false,false,false,false,false,false,false,false"
+        luns             = "0,1#2,3#4#5#6,7"
         names            = "data#log#shared#usrsap#backup"
         lv_sizes         = "100#100#100#100#100"
         paths            = "/hana/data#/hana/log#/hana/shared#/usr/sap#/hana/backup"
@@ -38,8 +38,8 @@ locals {
         writeaccelerator = "false,false,false,false,false,false"
         luns             = "0,1,2#3#4#5"
         names            = "datalog#shared#usrsap#backup"
-        lv_sizes         = "70,100#100#100#100#100"
-        paths            = "/hana/data#/hana/log#/hana/shared#/usr/sap#/hana/backup"
+        lv_sizes         = "70,100#100#100#100"
+        paths            = "/hana/data,/hana/log#/hana/shared#/usr/sap#/hana/backup"
       }
     }
     medium_sap_hana = {
@@ -51,9 +51,9 @@ locals {
         caching          = "ReadOnly,ReadOnly,ReadOnly,ReadOnly,ReadOnly,None"
         writeaccelerator = "false,false,false,false,false,false"
         luns             = "0,1,2#3#4#5"
-        names            = "data#log#shared#usrsap#backup"
+        names            = "datalog#shared#usrsap#backup"
         lv_sizes         = "70,100#100#100#100#100"
-        paths            = "/hana/data#/hana/log#/hana/shared#/usr/sap#/hana/backup"
+        paths            = "/hana/data,/hana/log#/hana/shared#/usr/sap#/hana/backup"
       }
     }
     large_sap_hana = {


### PR DESCRIPTION
The disk configuration is wrong in the `Small` size.
This fixes the error.

**Edit**:
There were more errors rather than only the `Small` size. Commit amended to fix all of them

**FYI**: @petersatsuse