### PR TITLE
Feature/storage account check

### DIFF
--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -101,9 +101,8 @@ class PlansController < ApplicationController
 
   def sanity_check
     # Check storage account values sanity
-    unless (result = check_storage_account) == true
-      return result
-    end
+    storage_result = check_storage_account
+    return storage_result if storage_result.is_a?(Hash)
 
     # Check terraform plan sanity
     plan_result = check_terraform_plan
@@ -128,8 +127,8 @@ class PlansController < ApplicationController
       var_file:  Variable.load.export_path
     }
     result = terra.plan(args)
-    if result.is_a?(Hash)
-      File.delete(path_to_file) if File.exist?(terra.saved_plan_path)
+    if result.is_a?(Hash) && File.exist?(terra.saved_plan_path)
+      File.delete(terra.saved_plan_path)
     end
     return result
   end

--- a/app/services/storage_account.rb
+++ b/app/services/storage_account.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'net/https'
+require 'uri'
+require 'base64'
+
+# Class to wrap all storage account operations
+class StorageAccount
+  include I18n
+
+  X_MS_VERSION = '2018-11-09'
+
+  def check_resource(account, key, resource)
+    # The callas are based on:
+    # https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-metadata
+    # https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-metadata
+    if File.extname(resource).present?
+      # The resource is a file
+      parameters = "#{resource}?comp=metadata"
+      resource = "#{resource}?comp=metadata"
+    else
+      # The resource is a folder
+      parameters = resource
+      resource = "#{resource}?restype=directory"
+    end
+
+    res = request(account, key, resource, parameters)
+
+    return true if res.is_a?(Net::HTTPOK)
+
+    output = if res.is_a?(Net::HTTPResponse)
+      res.message
+    else
+      res
+    end
+
+    return {
+      error: {
+        message: 'Error checking the storage account data',
+        output:  "#{I18n.t('storage_account_error')}<br><br>#{output}"
+      }
+    }
+  end
+
+  private
+
+  def request(account, key, resource, parameters)
+    # Based on https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
+    Rails.logger.debug 'New storage account request...'
+    return "Invalid key format (check if the key finishes with '==')." unless key =~ /.*==/
+
+    url = "https://#{account}.file.core.windows.net/#{resource}"
+    xm_ms_date = Time.current.strftime('%a, %d %b %Y %H:%M:%S GMT')
+    canonicalized_resources = "/#{account}/#{parameters}"
+    canonicalized_headers = "x-ms-date:#{xm_ms_date}\nx-ms-version:#{X_MS_VERSION}"
+    string_to_sign = "GET\n\n\n\n#{canonicalized_headers}\n#{canonicalized_resources}"
+    Rails.logger.debug "String to sign: #{string_to_sign}"
+
+    digest = OpenSSL::Digest.new('sha256')
+    signature = Base64.encode64(
+      OpenSSL::HMAC.digest(digest, Base64.decode64(key), string_to_sign.encode('utf-8'))
+    ).strip
+
+    uri = URI.parse(url)
+
+    https = Net::HTTP.new(uri.host, uri.port)
+    https.use_ssl = true
+
+    req = Net::HTTP::Get.new(uri)
+    req['x-ms-date'] = xm_ms_date
+    req['x-ms-version'] = X_MS_VERSION
+    req['Authorization'] = "SharedKeyLite #{account}:#{signature}"
+
+    https.request(req)
+  rescue SocketError => e
+    Rails.logger.error "Error connecting to the storage account: #{e}"
+    "#{e}."
+  end
+end

--- a/app/views/plans/_error.haml
+++ b/app/views/plans/_error.haml
@@ -1,1 +1,1 @@
-%p= @error[:output]
+%p= @error[:output].html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,9 @@ en:
   password_hide: "Hide password"
   autoscroll: "Autoscroll"
   unsupported: "Beta*"
+  storage_account_error: |
+    The provided storage account name or key are not valid. Update the <b>Storage account name</b>,
+    <b>Storage account key</b> or <b>Hana installation software path</b> variables.
 
   #password key is used to check whether a form field should be of type
   # "password" rather than "text"

--- a/spec/services/storage_account_spec.rb
+++ b/spec/services/storage_account_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'fileutils'
+require 'net/http'
+require 'net/https'
+
+RSpec.describe StorageAccount, type: :service do
+  let(:storage_account_instance) { described_class.new }
+
+  before do
+    I18n.backend.store_translations(:en, storage_account_error: 'storage account error')
+  end
+
+  it 'send a file request' do
+    net_http_resp = Net::HTTPOK.new(1.0, 200, 'OK')
+    allow(storage_account_instance).to receive(:request).and_return(net_http_resp)
+
+    result = storage_account_instance.check_resource('account', 'key', 'file.txt')
+
+    expect(result).to eq(true)
+
+    expect(storage_account_instance).to(
+      have_received(:request)
+        .with(
+          'account',
+          'key',
+          'file.txt?comp=metadata',
+          'file.txt?comp=metadata'
+        )
+    )
+  end
+
+  it 'send a directory request' do
+    net_http_resp = Net::HTTPOK.new(1.0, 200, 'OK')
+    allow(storage_account_instance).to receive(:request).and_return(net_http_resp)
+
+    result = storage_account_instance.check_resource('account', 'key', 'folder')
+
+    expect(result).to eq(true)
+
+    expect(storage_account_instance).to(
+      have_received(:request)
+        .with(
+          'account',
+          'key',
+          'folder?restype=directory',
+          'folder'
+        )
+    )
+  end
+
+  it 'send an invalid request' do
+    net_http_resp = Net::HTTPResponse.new(1.0, 404, 'Error')
+    allow(storage_account_instance).to receive(:request).and_return(net_http_resp)
+
+    result = storage_account_instance.check_resource('account', 'key', 'folder')
+
+    expect(result).to eq(
+      {
+        error: {
+          message: 'Error checking the storage account data',
+          output:  'storage account error<br><br>Error'
+        }
+      }
+    )
+
+    expect(storage_account_instance).to(
+      have_received(:request)
+        .with(
+          'account',
+          'key',
+          'folder?restype=directory',
+          'folder'
+        )
+    )
+  end
+
+  it 'send request with invalid socket' do
+    allow(storage_account_instance).to receive(:request).and_return('socket error')
+
+    result = storage_account_instance.check_resource('account', 'key', 'folder')
+
+    expect(result).to eq(
+      {
+        error: {
+          message: 'Error checking the storage account data',
+          output:  'storage account error<br><br>socket error'
+        }
+      }
+    )
+
+    expect(storage_account_instance).to(
+      have_received(:request)
+        .with(
+          'account',
+          'key',
+          'folder?restype=directory',
+          'folder'
+        )
+    )
+  end
+
+  context 'with storage account requests' do
+    let!(:date) { Time.current.strftime('%a, %d %b %Y %H:%M:%S GMT') }
+    let!(:string_to_sign) { "GET\n\n\n\nx-ms-date:#{date}\nx-ms-version:2018-11-09\n/account/?comp=file" }
+    let!(:signature) do
+      Base64.encode64(
+        OpenSSL::HMAC.digest(
+          OpenSSL::Digest.new('sha256'), Base64.decode64('key'), string_to_sign.encode('utf-8')
+        )
+      ).strip
+    end
+    let!(:storage_request) do
+      stub_request(:get, 'https://account.file.core.windows.net/file')
+        .with(
+          headers: {
+            'Accept'          => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization'   => "SharedKeyLite account:#{signature}",
+            'Host'            => 'account.file.core.windows.net',
+            'User-Agent'      => 'Ruby',
+            'X-Ms-Date'       => date,
+            'X-Ms-Version'    => '2018-11-09'
+          }
+        ).to_return(body: 'OK')
+    end
+
+    it 'creates a request signature correctly' do
+      storage_account_instance.send(
+        :request, 'account', 'key==', 'file', '?comp=file'
+      )
+
+      expect(storage_request).to have_been_requested
+    end
+
+    it 'creates a request signature with invalid key' do
+      response = storage_account_instance.send(
+        :request, 'account', 'key', 'file', '?comp=file'
+      )
+      expect(response).to match('Invalid key format (check if the key finishes with \'==\').')
+    end
+
+    it 'creates a request signature with socket error' do
+      allow_any_instance_of(Net::HTTP).to receive(:request).and_raise(SocketError, 'error')
+
+      response = storage_account_instance.send(
+        :request, 'account', 'key==', 'file', '?comp=file'
+      )
+      expect(response).to match('error.')
+    end
+  end
+end


### PR DESCRIPTION
Include an Azure storage account check. This checks the storage account with the HANA software. Otherwise, errors might happen during the deployment if invalid data is set.

**This check only looks for a correct storage account file share. If it exists or not and if the storage account key is correct. It doesn't check if the files are HANA software**

If an error occurs, it is shown in the plan page, to follow with the same mechanism used by terraform plan failure.

Find the information about how the Azure rest api works in:
https://docs.microsoft.com/en-us/rest/api/storageservices/get-file-metadata
https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-metadata

Besides that, I have structured the code to make easy to add additional checks (like the ssh public key sanity check that will come after this PR).

**PD: Even though I have written many UT, there some few points that I was not able to cover. They are not that important, so I won't invest more time to cover one line as It is getting my a lot of time...**

Here some pics:
Invalid storage account used:
![image](https://user-images.githubusercontent.com/36370954/105718635-bdee4280-5f21-11eb-8258-b41e36ad877f.png)
Invalid key (mostly the last 2 `==` not added). For some reason the API rest works without them... but afterwards the CIFS mounting fails...
![image](https://user-images.githubusercontent.com/36370954/105718648-c181c980-5f21-11eb-97ae-6decf316e716.png)
Invalid key:
![image](https://user-images.githubusercontent.com/36370954/105718659-c3e42380-5f21-11eb-9c04-643501503a03.png)
Invalid resource (hana software path)
![image](https://user-images.githubusercontent.com/36370954/105718666-c6df1400-5f21-11eb-9358-6cef669e3d7c.png)
