### PR TITLE
Implement ssh key content server side validation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,6 +41,8 @@ en:
   password_hide: "Hide password"
   autoscroll: "Autoscroll"
   unsupported: "Beta*"
+  ssh_key_error: |
+    The provided authorized ssh key is not valid. Upload a correct ssh public key in <b>SSH authorized key file</b> (with .pub extension usually).
   storage_account_error: |
     The provided storage account name or key are not valid. Update the <b>Storage account name</b>,
     <b>Storage account key</b> or <b>Hana installation software path</b> variables.

--- a/spec/fixtures/sources_sap_azure/variables.tf.json
+++ b/spec/fixtures/sources_sap_azure/variables.tf.json
@@ -1,0 +1,20 @@
+{
+    "variable": {
+        "ssh_authorized_key_file": {
+            "type": "string",
+            "description": "Public ssh key file"
+        },
+        "storage_account_name": {
+            "type": "string",
+            "description": "Storage account name"
+        },
+        "storage_account_key": {
+            "type": "string",
+            "description": "Storage account key"
+        },
+        "hana_installation_software_path": {
+            "type": "string",
+            "description": "HANA installation path"
+        }
+    }
+}

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -3,10 +3,12 @@
 require 'ruby_terraform'
 
 module Helpers
-  def populate_sources(auth_plan: false, include_mocks: true)
+  def populate_sources(auth_plan: false, include_mocks: true, use_sap_azure: false)
     sources_dir =
       if auth_plan
         'sources_auth'
+      elsif use_sap_azure
+        'sources_sap_azure'
       else
         'sources'
       end


### PR DESCRIPTION
Validate SSH key value content in the server. Now, it will only allow SSH public keys. This will help to avoid incorrect usage of the key.
Unfortunately, this step is done in the planning stage. Otherwise, the changes should've been pretty major.

Besides that, improve how the UT about these validations are done.

Some pics:

![image](https://user-images.githubusercontent.com/36370954/106435923-c2f84800-6473-11eb-970e-da913eff5a24.png)
