### PR TITLE
Fix how the terraform project is initialized and validated

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,4 +12,6 @@ Rails.logger.level = Logger::INFO
 sources_path = ENV['TERRAFORM_SOURCES_PATH']
 sources_path ||= Rails.root.join('vendor', 'sources')
 Source.import_dir(sources_path, validate: false)
+sources = Source.all
+sources.each(&:export)
 Terraform.new.validate(true)


### PR DESCRIPTION
The terraform project is not initialized and validated properly during the database configuration.
This was due the source files were not imported.

This was causing a terraform initialization without the correct files. This was causing an error during the variables server side validation for the next reason (this is code flow):
- We set an incorrect ssh file
- Init terraform (empty folder)
- Validate - OK (empty file validation is correct)
- Files are copied during the variables controller usage
- We retry to upload the correct ssh file again
- Now, the terraform variable is reused (https://github.com/SUSE/blue-horizon-for-sap/blob/sap-azure/app/validators/source_validator.rb#L13)
- So the new `init` is not executed, and when it tries to run `validate` and finds new files, terraform asks for `init` and fails

To solve this, we just import the source files during `db:setup` usage.

Here some more logs about the error in `db:setup`:
- Before (check how `terraform init` is done in empty folder)
```
/home/xarbulu/.rvm/gems/ruby-2.7.0/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/abstract/transaction.rb:97: warning: The called method `initialize' is defined here
/home/xarbulu/.rvm/gems/ruby-2.7.0/gems/activerecord-5.2.4.4/lib/active_record/persistence.rb:705: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/xarbulu/.rvm/gems/ruby-2.7.0/gems/activerecord-5.2.4.4/lib/active_record/timestamp.rb:105: warning: The called method `_update_record' is defined here
-- create_table("key_values", {:force=>:cascade})
/home/xarbulu/.rvm/gems/ruby-2.7.0/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/sqlite3_adapter.rb:32: warning: rb_check_safe_obj will be removed in Ruby 3.0
   -> 0.0468s
-- create_table("sources", {:force=>:cascade})
   -> 0.0583s
/home/xarbulu/.rvm/gems/ruby-2.7.0/gems/activerecord-5.2.4.4/lib/active_record/connection_adapters/sqlite3_adapter.rb:32: warning: rb_check_safe_obj will be removed in Ruby 3.0
/home/xarbulu/.rvm/gems/ruby-2.7.0/gems/activemodel-5.2.4.4/lib/active_model/type/integer.rb:13: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/xarbulu/.rvm/gems/ruby-2.7.0/gems/activemodel-5.2.4.4/lib/active_model/type/value.rb:8: warning: The called method `initialize' is defined here
D, [2021-02-03T14:17:06.212367 #28285] DEBUG -- : Running '/usr/bin/terraform init -backend=false -no-color'.
Terraform initialized in an empty directory!

The directory has no Terraform configuration files. You may begin working
with Terraform immediately by creating Terraform configuration files.
D, [2021-02-03T14:17:06.302799 #28285] DEBUG -- : Running '/usr/bin/terraform validate -no-color /home/xarbulu/Workspace/sap_squad/blue-horizon/tmp/terraform'.
Success! The configuration is valid.
```

Now, after the fix. The sources file are copied
```
D, [2021-02-03T14:17:26.982981 #28444] DEBUG -- : Running '/usr/bin/terraform init -backend=false -no-color'.
Initializing modules...
Downloading git::https://github.com/SUSE/ha-sap-terraform-deployments.git?ref=sap-blue-horizon for bluehorizon...
- bluehorizon in .terraform/modules/bluehorizon/azure
- bluehorizon.bastion in .terraform/modules/bluehorizon/azure/modules/bastion
- bluehorizon.bastion.bastion_on_destroy in .terraform/modules/bluehorizon/generic_modules/on_destroy
- bluehorizon.bastion.bastion_provision in .terraform/modules/bluehorizon/generic_modules/salt_provisioner
- bluehorizon.bastion.os_image_reference in .terraform/modules/bluehorizon/azure/modules/os_image_reference
- bluehorizon.common_variables in .terraform/modules/bluehorizon/generic_modules/common_variables
- bluehorizon.drbd_node in .terraform/modules/bluehorizon/azure/modules/drbd_node
- bluehorizon.drbd_node.drbd_on_destroy in .terraform/modules/bluehorizon/generic_modules/on_destroy
- bluehorizon.drbd_node.drbd_provision in .terraform/modules/bluehorizon/generic_modules/salt_provisioner
- bluehorizon.drbd_node.os_image_reference in .terraform/modules/bluehorizon/azure/modules/os_image_reference
- bluehorizon.hana_node in .terraform/modules/bluehorizon/azure/modules/hana_node
- bluehorizon.hana_node.hana_on_destroy in .terraform/modules/bluehorizon/generic_modules/on_destroy
- bluehorizon.hana_node.hana_provision in .terraform/modules/bluehorizon/generic_modules/salt_provisioner
- bluehorizon.hana_node.os_image_reference in .terraform/modules/bluehorizon/azure/modules/os_image_reference
- bluehorizon.iscsi_server in .terraform/modules/bluehorizon/azure/modules/iscsi_server
- bluehorizon.iscsi_server.iscsi_on_destroy in .terraform/modules/bluehorizon/generic_modules/on_destroy
- bluehorizon.iscsi_server.iscsi_provision in .terraform/modules/bluehorizon/generic_modules/salt_provisioner
- bluehorizon.iscsi_server.os_image_reference in .terraform/modules/bluehorizon/azure/modules/os_image_reference
- bluehorizon.local_execution in .terraform/modules/bluehorizon/generic_modules/local_exec
- bluehorizon.monitoring in .terraform/modules/bluehorizon/azure/modules/monitoring
- bluehorizon.monitoring.monitoring_on_destroy in .terraform/modules/bluehorizon/generic_modules/on_destroy
- bluehorizon.monitoring.monitoring_provision in .terraform/modules/bluehorizon/generic_modules/salt_provisioner
- bluehorizon.monitoring.os_image_reference in .terraform/modules/bluehorizon/azure/modules/os_image_reference
- bluehorizon.netweaver_node in .terraform/modules/bluehorizon/azure/modules/netweaver_node
- bluehorizon.netweaver_node.netweaver_on_destroy in .terraform/modules/bluehorizon/generic_modules/on_destroy
- bluehorizon.netweaver_node.netweaver_provision in .terraform/modules/bluehorizon/generic_modules/salt_provisioner
- bluehorizon.netweaver_node.os_image_reference in .terraform/modules/bluehorizon/azure/modules/os_image_reference

Initializing provider plugins...
- Finding hashicorp/tls versions matching "3.0.0"...
- Finding hashicorp/azurerm versions matching "~> 2.32.0, ~> 2.32.0"...
- Finding hashicorp/null versions matching "3.0.0"...
- Installing hashicorp/tls v3.0.0...
- Installed hashicorp/tls v3.0.0 (signed by HashiCorp)
- Installing hashicorp/azurerm v2.32.0...
- Installed hashicorp/azurerm v2.32.0 (signed by HashiCorp)
- Installing hashicorp/null v3.0.0...
- Installed hashicorp/null v3.0.0 (signed by HashiCorp)

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.
D, [2021-02-03T14:17:40.246479 #28444] DEBUG -- : Running '/usr/bin/terraform validate -no-color /home/xarbulu/Workspace/sap_squad/blue-horizon/tmp/terraform'.
Success! The configuration is valid.
```