### PR TITLE
Add download link to the deployment logs

### DIFF
--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -20,6 +20,7 @@ $(function () {
     $(".list-group-flush a").addClass("disabled");
     $("#loading").show();
     $("a[data-toggle]").tooltip("hide");
+    $("#download").addClass("disabled");
     intervalId = setTimeout(function () {
       fetch_output(finished, intervalId);
     }, 5000);
@@ -113,6 +114,7 @@ function fetch_output(finished, intervalId) {
     success: function success(data) {
       if (data.error !== null) {
         $("#loading").hide(); // show rails flash message
+        $("#download").removeClass("disabled");
 
         $("#error_message").text("Deploy operation has failed.");
         $("#flash").show(); // show terraform error message in output section
@@ -136,6 +138,7 @@ function fetch_output(finished, intervalId) {
             fetch_output();
           }, 5000);
         } else {
+          $("#download").removeClass("disabled");
           $(".steps-container .btn.disabled").removeClass("disabled");
           $("#loading").hide();
           finished = true;
@@ -150,6 +153,7 @@ function fetch_output(finished, intervalId) {
       $("#flash").show();
       $(".steps-container .btn.disabled").removeClass("disabled");
       $("#loading").hide();
+      $("#download").removeClass("disabled");
       update_progress(data, true);
     }
   });
@@ -157,3 +161,10 @@ function fetch_output(finished, intervalId) {
     $("#flash").hide();
   });
 }
+
+$("#download").click(function () {
+  var link = document.createElement("a");
+  link.href = "data:text/plain;charset=UTF-8," + escape($("#output").html());
+  link.setAttribute("download", "execution.log");
+  link.click();
+});

--- a/app/assets/stylesheets/deploys.css
+++ b/app/assets/stylesheets/deploys.css
@@ -16,3 +16,9 @@
 .linebreaks {
     white-space: pre-wrap;
 }
+.horizontal {
+    display: flex;
+}
+.download_content {
+    margin-right: 25px;
+}

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -33,7 +33,7 @@ class DeploysController < ApplicationController
   def send_current_status
     if Terraform.stderr.is_a?(StringIO) && !Terraform.stderr.string.empty?
       error = Terraform.stderr.string
-      content = error
+      content = Terraform.stdout.string + error
       success = false
       write_output(content, success)
     elsif Terraform.stdout.is_a?(StringIO)

--- a/app/controllers/plans_controller.rb
+++ b/app/controllers/plans_controller.rb
@@ -88,9 +88,14 @@ class PlansController < ApplicationController
   end
 
   def cleanup
+    log_file = File.basename(Rails.configuration.x.terraform_log_filename, '.*')
+    log_file_abs = Rails.configuration.x.source_export_dir.join(log_file)
     exports = Rails.configuration.x.source_export_dir.join('*')
-    Rails.logger.debug("cleaning up #{exports}")
-    rm_r(Dir.glob(exports), secure: true)
+    filtered_exports = Dir.glob(exports).reject do |item|
+      item.match(/#{log_file_abs}.*/)
+    end
+    Rails.logger.debug("cleaning up #{filtered_exports}")
+    FileUtils.rm_r(filtered_exports, secure: true)
   end
 
   def prep

--- a/app/views/deploys/_details.html.haml
+++ b/app/views/deploys/_details.html.haml
@@ -1,4 +1,5 @@
-%div.float-right
+%div.float-right.horizontal
+  %a.download_content#download= t('deploy.download_content')
   %label.form-check-label
     = check_box('deploy_log', 'autoscroll', class: 'form-check-input', checked: true)
     = t('autoscroll')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -67,6 +67,7 @@ en:
     variables: "Variables"
     plan: "Plan"
     download_plan: "Download plan"
+    download_logs: "Download execution logs"
     deploy: "Deploy"
     home: "Next steps"
     download: "Download"
@@ -110,6 +111,7 @@ en:
     copy: "Copy to clipboard"
     copied: "Copied!"
     unsupported: "Beta features are not covered by SUSE Enterprise Support licenses and are only provided as a technical preview"
+    download_logs: "Download execution logs"
 
   page_title:
     cluster: "SAP System size"
@@ -152,6 +154,7 @@ en:
 
   # Deployment view and progress bar texts
   deploy:
+    download_content: "Download content"
     details: "Installation details"
     not_started: "Not started"
     in_progress: "Installation in progress..."

--- a/spec/controllers/deploys_controller_spec.rb
+++ b/spec/controllers/deploys_controller_spec.rb
@@ -66,6 +66,10 @@ RSpec.describe DeploysController, type: :controller do
         receive(:stderr)
           .and_return(StringIO.new('Something went wrong'))
       )
+      allow(ruby_terraform.configuration).to(
+        receive(:stdout)
+          .and_return(StringIO.new('Something happened\n'))
+      )
       allow(controller).to(
         receive(:update_progress)
           .and_return('progress')
@@ -77,7 +81,7 @@ RSpec.describe DeploysController, type: :controller do
       expect(File).to exist(filename)
       file_content = File.read(filename)
       expect(
-        file_content.include?('Something went wrong')
+        file_content.include?('Something happened\nSomething went wrong')
       ).to be true
     end
 


### PR DESCRIPTION
Improvements on the logging system:

- Concatenate the stdout stream during deployment failure. Otherwise regular logs are lost
- Avoid removing the ruby-terraform log files during a new plan. They are wiped out always
- Add a new download link to the deployment stage. It is an extremely basic javascript code to download the content of the output area. I didn't want to make it more complicated as the idea is to have a simple way to get the logs. The user always can go to the machine to get the complete logs of the blue-horizon execution.

Here a short demo about the download link (the link is disabled during executions):
![download-link](https://user-images.githubusercontent.com/36370954/106923848-c824f380-670e-11eb-93f5-e8d9e5b1fae9.gif)
