### PR TITLE
Add refresh to the dashboards

### DIFF
--- a/vendor/customization.json
+++ b/vendor/customization.json
@@ -15,10 +15,10 @@
           "key": "monitor",
           "url": "/dashboards/ha_cluster",
           "sidebar": {
-            "ha_cluster": "http://%{bastion_ip}:3000/d/Q5YJpwtZk1/clusterlabs-ha-cluster-details?orgId=1&kiosk",
+            "ha_cluster": "http://%{bastion_ip}:3000/d/Q5YJpwtZk1/clusterlabs-ha-cluster-details?orgId=1&kiosk&refresh=30s",
             "hana_dbs": {
-              "main_tenant": "http://%{bastion_ip}:3000/d/EcC4JDFWz2/sap-hana?orgId=1&var-DS_PROMETHEUS=Prometheus&var-node_ip=%{hana_ip}&var-sid=%{sid}&var-instance_number=%{instance_number}&var-database_name=%{sid}&kiosk",
-              "systemdb": "http://%{bastion_ip}:3000/d/EcC4JDFWz2/sap-hana?orgId=1&var-DS_PROMETHEUS=Prometheus&var-node_ip=%{hana_ip}&var-sid=%{sid}&var-instance_number=%{instance_number}&var-database_name=SYSTEMDB&kiosk"
+              "main_tenant": "http://%{bastion_ip}:3000/d/EcC4JDFWz2/sap-hana?orgId=1&var-DS_PROMETHEUS=Prometheus&var-node_ip=%{hana_ip}&var-sid=%{sid}&var-instance_number=%{instance_number}&var-database_name=%{sid}&kiosk&refresh=30s",
+              "systemdb": "http://%{bastion_ip}:3000/d/EcC4JDFWz2/sap-hana?orgId=1&var-DS_PROMETHEUS=Prometheus&var-node_ip=%{hana_ip}&var-sid=%{sid}&var-instance_number=%{instance_number}&var-database_name=SYSTEMDB&kiosk&refresh=30s"
             }
           }
       },


### PR DESCRIPTION
Without the `refresh` parameter in the dashboards, the views are static and the user needs to refresh the page to see any updated.

I have added 60 seconds refresh to HA and HANADB dashboards.
The TUNING dashboards is not changed, as it doesn't receive changes usually (even though we could add the refresh).

Let me know what do you think and if the used times are good