### PR TITLE
Improve how the rollback is used showing the progress in the app

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,6 +9,7 @@
 Metrics/ClassLength:
   Exclude:
     - "app/services/terraform.rb"
+    - "app/controllers/deploys_controller.rb"
 
 Metrics/ModuleLength:
   Exclude:

--- a/app/assets/javascripts/deploys.js
+++ b/app/assets/javascripts/deploys.js
@@ -13,7 +13,15 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 $(function () {
   var intervalId = undefined;
   var finished = false;
-  $("#submit-deploy").bind("ajax:beforeSend", function () {
+  $("#submit-deploy,#submit-destroy").bind("ajax:beforeSend", function () {
+    finished = false;
+    // Cannot bring the text messages from the server
+    if (this.id == "submit-deploy") {
+      $("#message").text("Deployment operation started. Find more details in Installation details box");
+    } else if (this.id == "submit-destroy") {
+      $("#message").text("Rollback operation started. Find more details in Installation details box");
+    }
+    $("#flash").show().removeClass('alert-success alert-danger').addClass("alert-info");
     $("#output").text("");
     $(this).addClass("no-hover");
     $(".float-right.steps-container .btn").addClass("disabled");
@@ -41,6 +49,10 @@ $(function () {
   }).bind("ajax:error", function () {
     $("#loading").hide();
     clearTimeout(intervalId);
+  });
+
+  $("#flash .close").click(function () {
+    $("#flash").hide();
   });
 });
 
@@ -114,9 +126,6 @@ function fetch_output(finished, intervalId) {
       if (data.error !== null) {
         $("#loading").hide(); // show rails flash message
 
-        $("#error_message").text("Deploy operation has failed.");
-        $("#flash").show(); // show terraform error message in output section
-
         $("#output").text($("#output").text() + data.error);
         clearTimeout(intervalId);
         $(".steps-container .btn.disabled").removeClass("disabled");
@@ -139,6 +148,7 @@ function fetch_output(finished, intervalId) {
           }, 5000);
         } else {
           $(".steps-container .btn.disabled").removeClass("disabled");
+          $("#submit-destroy").addClass("disabled");
           $(".nav-wrap .menu-item a").removeClass("disabled");
           $("#loading").hide();
           finished = true;
@@ -149,8 +159,6 @@ function fetch_output(finished, intervalId) {
     error: function error(data) {
       var endIndex = data.responseText.indexOf("#");
       if (endIndex == -1) endIndex = data.responseText.indexOf("\n");
-      $("#error_message").text(data.responseText.substring(0, endIndex));
-      $("#flash").show();
       $(".nav-wrap .menu-item a").removeClass("disabled");
       $(".steps-container .btn.disabled").removeClass("disabled");
       $(".steps-container .btn.btn-primary").addClass("disabled");

--- a/app/helpers/authorization_helper.rb
+++ b/app/helpers/authorization_helper.rb
@@ -138,6 +138,10 @@ module AuthorizationHelper
     export_file_exists?('current_plan')
   end
 
+  def deployment_exists?
+    File.exist?(Terraform.statefilename)
+  end
+
   def terraform_running?
     KeyValue.get(:active_terraform_action).present?
   end

--- a/app/services/terraform.rb
+++ b/app/services/terraform.rb
@@ -134,7 +134,7 @@ class Terraform
       RubyTerraform.apply(args)
     end
   rescue RubyTerraform::Errors::ExecutionError
-    nil
+    return 'Error: Terraform apply has failed.'
   ensure
     KeyValue.set(:active_terraform_action, nil)
   end
@@ -163,8 +163,10 @@ class Terraform
     KeyValue.set(:active_terraform_action, 'destroy')
     destroy_args = {
       directory:    Rails.configuration.x.source_export_dir,
-      auto_approve: true
+      auto_approve: true,
+      no_color:     true
     }
+    set_output
     in_export_dir do
       RubyTerraform.destroy(destroy_args)
     end

--- a/app/views/deploys/flash.js.haml
+++ b/app/views/deploys/flash.js.haml
@@ -1,0 +1,7 @@
+:plain
+  $('#flash')
+    .removeClass('alert-success alert-danger alert-info')
+    .addClass("#{@flash_data[:state]}")
+    .show()
+    .find('span')
+    .html("#{@flash_data[:message]}");

--- a/app/views/deploys/show.html.haml
+++ b/app/views/deploys/show.html.haml
@@ -1,5 +1,5 @@
-%div#flash.alert.alert-danger.alert-dismissable.fade.show{style: 'display: none;'}
-  %span#error_message
+%div#flash.alert.alert-dismissable.fade.show{style: 'display: none;'}
+  %span#message
   %button.close{ type: 'button' }
     %i.eos-icons close
 %div.card
@@ -14,7 +14,7 @@
       = render 'details'
 %p.clearfix
   %div.float-left.btn-group.steps-container
-    = link_to deploy_path, class: "btn btn-danger disabled", id: "destroy", title: t('tooltips.run'), data: { method: :delete, toggle: 'tooltip', disable_with: t('running') } do
+    = link_to deploy_path, class: "btn btn-danger #{'disabled' unless deployment_exists?}", id: "submit-destroy", title: t('tooltips.rollback'), data: { method: :delete, remote: true, toggle: 'tooltip', disable_with: t('running') } do
       %i.eos-icons cloud_off
       = t('rollback')
   %div.float-right.btn-group.steps-container

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,6 +97,11 @@ en:
     invalid_variables: "Variable definitions are invalid! Please check the deployment scripts."
     deployment_finished: "The deployment has already been executed. It cannot be repeated."
     console_not_ready: "The console is not ready yet. The deployment must be completed first."
+    deploy:
+      destroy_success: "Rollback operation successfully executed"
+      destroy_error: "Rollback operation failed. Please, check the logs in the Installation details box"
+      apply_success: "Deployment operation successfully executed. Click in Finish to start using the console"
+      apply_error: "Deployment operation failed. Execute the rollback to destroy the current environment"
 
   tooltips:
     prior_step: "Go back without saving changes"
@@ -110,6 +115,7 @@ en:
     copy: "Copy to clipboard"
     copied: "Copied!"
     unsupported: "Beta features are not covered by SUSE Enterprise Support licenses and are only provided as a technical preview"
+    rollback: "Destroy the current deployment. This action is required if the deployment failed and new retry is intended"
 
   page_title:
     cluster: "SAP System size"

--- a/spec/controllers/deploys_controller_spec.rb
+++ b/spec/controllers/deploys_controller_spec.rb
@@ -37,6 +37,7 @@ RSpec.describe DeploysController, type: :controller do
       expect(KeyValue.get(:planned_resources_count)).to eq(3)
       expect(KeyValue.get(:total_steps)).to eq(4)
       expect(KeyValue.get(:completed_steps)).to eq(0)
+      expect(KeyValue.get(:deploy_action)).to eq('apply')
       expect(instance_terra).to(
         have_received(:apply)
           .with(
@@ -45,20 +46,36 @@ RSpec.describe DeploysController, type: :controller do
             no_color:     true
           )
       )
+      expect(controller.instance_variable_get(:@flash_data)).to(
+        eql(
+          {
+            message: 'Deployment operation successfully executed. Click in Finish to start using the console',
+            state:   'alert-success'
+          }
+        )
+      )
     end
 
-    it 'raise exception' do
+    it 'deploys with an error' do
       allow(instance_terra).to(
         receive(:get_planned_resources)
           .and_return(['1', '2', '3'])
       )
       allow(instance_terra).to(
         receive(:apply)
-          .and_raise(RubyTerraform::Errors::ExecutionError)
+          .and_return('error applying terraform')
       )
-      expect do
-        get :update, format: :json
-      end.to raise_exception(RubyTerraform::Errors::ExecutionError)
+
+      get :update, format: :json
+
+      expect(controller.instance_variable_get(:@flash_data)).to(
+        eql(
+          {
+            message: 'Deployment operation failed. Execute the rollback to destroy the current environment',
+            state:   'alert-danger'
+          }
+        )
+      )
     end
 
     it 'writes error in the log' do
@@ -82,6 +99,8 @@ RSpec.describe DeploysController, type: :controller do
     end
 
     it 'can show deploy output' do
+      allow(KeyValue).to receive(:get).and_call_original
+      allow(KeyValue).to receive(:get).with(:deploy_action).and_return('apply')
       allow(Terraform).to(
         receive(:stdout)
           .and_return(
@@ -107,8 +126,32 @@ RSpec.describe DeploysController, type: :controller do
       expect(response).to be_success
     end
 
+    it 'does not send progress in destroy' do
+      allow(KeyValue).to receive(:get).and_call_original
+      allow(KeyValue).to receive(:get).with(:deploy_action).and_return('destroy')
+      allow(Terraform).to(
+        receive(:stdout)
+          .and_return(
+            StringIO.new('hello world! Destroy complete!')
+          )
+      )
+      allow(controller).to receive(:update_progress)
+
+      allow(ruby_terraform).to receive(:apply)
+
+      get :send_current_status, format: :json
+
+      expect(controller).not_to(
+        have_received(:update_progress)
+      )
+
+      expect(response).to be_success
+    end
+
     it 'can show error output when deploy fails' do
       allow(JSON).to receive(:parse).and_return(foo: 'bar')
+      allow(KeyValue).to receive(:get).and_call_original
+      allow(KeyValue).to receive(:get).with(:deploy_action).and_return('apply')
 
       allow(Terraform).to receive(:stderr).and_return(StringIO.new('Error'))
       allow(Terraform).to receive(:stdout).and_return(StringIO.new('Creating'))
@@ -132,17 +175,25 @@ RSpec.describe DeploysController, type: :controller do
 
   context 'when destroying terraform resources' do
     let(:ruby_terraform) { RubyTerraform }
+    let(:tfstate) { working_path.join('terraform.tfstate') }
 
     it 'destroys the resources deployed' do
       allow(ruby_terraform).to receive(:destroy)
       allow(File).to receive(:exist?).and_return(true)
-      allow(controller).to receive(:redirect_to).with(action: 'show')
+      allow(File).to receive(:delete).with(tfstate)
 
-      delete :destroy
+      delete :destroy, format: :json
 
       expect(response).to be_success
-      expect(flash[:notice]).to(
-        include('Terraform resources have been destroyed.')
+      expect(KeyValue.get(:deploy_action)).to eq('destroy')
+
+      expect(controller.instance_variable_get(:@flash_data)).to(
+        eql(
+          {
+            message: 'Rollback operation successfully executed',
+            state:   'alert-success'
+          }
+        )
       )
     end
 
@@ -152,13 +203,17 @@ RSpec.describe DeploysController, type: :controller do
           .and_raise(RubyTerraform::Errors::ExecutionError)
       )
       allow(File).to receive(:exist?).and_return(true)
-      allow(controller).to receive(:redirect_to).with(action: 'show')
 
-      delete :destroy
+      delete :destroy, format: :json
 
       expect(response).to be_success
-      expect(flash[:error]).to(
-        include('Error: Terraform destroy has failed.')
+      expect(controller.instance_variable_get(:@flash_data)).to(
+        eql(
+          {
+            message: 'Rollback operation failed. Please, check the logs in the Installation details box',
+            state:   'alert-danger'
+          }
+        )
       )
     end
   end


### PR DESCRIPTION
Improvement of the rollback function.

Now, the rollback logs are displayed in the scrollable area the same way as the deployment logs. The task list and the progress bar are not updated though, as this would be extremely difficult to achieve.

In order to improve a bit how the user notices what's going on, I have used flash message (I know that not everyone likes them, but it is the easiest way and it was almost already in place).

Here some shots:
-  The start flash message are hardcoded in the js code, I wasn't able to modify them as they are executed when the ajax call is started. This would require much more difficult changes on the code. It doesn't worth in my opinion
- The finish flash messages are retrieved from the server and are configurable through the language configuration file
Deployment started:
![image](https://user-images.githubusercontent.com/36370954/107229710-70440080-6a1e-11eb-9407-30cd282f6fcf.png)

Deployment failed:
![image](https://user-images.githubusercontent.com/36370954/107229780-85b92a80-6a1e-11eb-89af-225851f40471.png)

Rollback started:
![image](https://user-images.githubusercontent.com/36370954/107229819-910c5600-6a1e-11eb-8d6f-adc7d846033a.png)

Rollback finished:
![image](https://user-images.githubusercontent.com/36370954/107229938-b6995f80-6a1e-11eb-85ec-471e27b5a1aa.png)

