### PR TITLE
Use official monitoring

### DIFF
--- a/vendor/sources/main.tf
+++ b/vendor/sources/main.tf
@@ -187,7 +187,5 @@ module "bluehorizon" {
   provisioning_log_level             = "info"
   provisioning_output_colored        = false
   netweaver_master_password          = "not used"
-  # ha_sap_deployment_repo variable must be removed as soon as all the packages come from official channels
-  # now the saptune_exporter is missing
-  ha_sap_deployment_repo             = "https://download.opensuse.org/repositories/network:ha-clustering:sap-deployments:devel"
+  monitoring_os_image                = "suse:sles-15-sp2-monitoring:gen2:latest"
 }


### PR DESCRIPTION
Use the new SLES monitoring image: `suse:sles-15-sp2-monitoring:gen2:latest`
With this, we can remove the `devel` project repository as all the needed packages are in the new image