### PR TITLE
Rename the app to use the new full name

### DIFF
--- a/app/assets/stylesheets/override.scss
+++ b/app/assets/stylesheets/override.scss
@@ -67,5 +67,30 @@ i.eos-icons.no-trailing-space {
   min-width: 8em;
 }
 
+$main-menu-width: 320px;
+$main-menu-width-collapsed: 60px;
+
+.main-menu {
+  width: $main-menu-width !important;
+  max-width: $main-menu-width !important;
+}
+
+.collapsed-sidebar.main-menu {
+  width: $main-menu-width-collapsed !important;
+  max-width: $main-menu-width-collapsed !important;
+}
+
+.content {
+  margin-left: $main-menu-width;
+}
+
+.collapsed-sidebar.content {
+  margin-left: $main-menu-width-collapsed !important;
+}
+
+.footer-side-menu {
+  width: $main-menu-width;
+}
+
 // A placeholder for custom CSS.
 // This will be loaded last, and overrride other content.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -123,7 +123,7 @@ en:
     cluster: "SAP System size"
     plan: "Plan your deployment"
     deploy: "Deploy your cluster"
-    home: "Welcome to your SAP console!"
+    home: "Welcome to your SUSE Console for SAP Applications!"
     source: "Working directly with deployment source scripts"
     resources: "Additional resources"
 

--- a/vendor/locales/custom-en.yml
+++ b/vendor/locales/custom-en.yml
@@ -3,9 +3,9 @@
 
 en:
   # Application title - shown on the home page
-  title: "SUSE SAP Console"
+  title: "SUSE Console for SAP Applications"
   # Abbreviated title for use in navigation
-  short_title: "SUSE SAP Console"
+  short_title: "SUSE Console for SAP Applications"
   # Sidebar
   sidebar:
     welcome: "Deployment"
@@ -26,7 +26,7 @@ en:
     cluster: "SAP System size"
     plan: "Review and Confirm"
     deploy: "Deploy your SAP environment"
-    home: "Welcome to your SUSE SAP console"
+    home: "Welcome to your SUSE Console for SAP Applications"
     source: "Working directly with deployment source scripts"
     resources: "Additional resources"
 
@@ -143,7 +143,7 @@ en:
     Your SAP environment has been created successfully.
     You can find the created resources <a href="%{resource_group_url}" target="_blank">clicking here</a>.
 
-    Now, you can continue using the SAP console to **monitor** and **tune** the created machines using the top menu.
+    Now, you can continue using the SUSE Console for SAP Applications to **monitor** and **tune** the created machines using the top menu.
 
     Besides that, you can download the files created during the deployment. Check for more options in the **resources** tab.
 


### PR DESCRIPTION
Rename the app to use the new full name `SUSE Console for SAP Applications`.
This requires to widen a bit the left sidebar. I have tested the collapsed option too

![image](https://user-images.githubusercontent.com/36370954/113865476-6a636500-97ac-11eb-8437-0a595c6c1b97.png)
![image](https://user-images.githubusercontent.com/36370954/113865508-74856380-97ac-11eb-9918-4e3a6ab5d976.png)
